### PR TITLE
Return non-zero exit codes on packmol failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ oall = cenmass.o \
        initial.o \
        title.o \
        setsizes.o \
+       exit_codes.o \
        getinp.o \
        strlength.o \
        output.o \
@@ -111,7 +112,10 @@ devel : $(oall)
 #
 # Modules
 #
-modules = sizes.o compute_data.o usegencan.o input.o flashmod.o swaptypemod.o ahestetic.o
+modules = exit_codes.o sizes.o compute_data.o usegencan.o input.o flashmod.o \
+          swaptypemod.o ahestetic.o
+exit_codes.o : exit_codes.f90
+	@$(FORTRAN) $(FLAGS) -c exit_codes.f90
 sizes.o : sizes.f90 
 	@$(FORTRAN) $(FLAGS) -c sizes.f90
 compute_data.o : compute_data.f90 sizes.o

--- a/exit_codes.f90
+++ b/exit_codes.f90
@@ -8,6 +8,7 @@ module exit_codes
 
   IMPLICIT NONE
 
+  ! Codes 1, 2, 126 – 165 and 255 have special meaning
   integer, parameter :: exit_code_success = 0
   integer, parameter :: exit_code_general_error = 170
   integer, parameter :: exit_code_input_error = 171

--- a/exit_codes.f90
+++ b/exit_codes.f90
@@ -1,0 +1,17 @@
+!
+!  Written by Alexandr Fonari, 2022.
+!  Copyright (c) 2009-2018, Leandro Martínez, Jose Mario Martinez,
+!  Ernesto G. Birgin.
+!  
+
+module exit_codes
+
+  IMPLICIT NONE
+
+  integer, parameter :: exit_code_success = 0
+  integer, parameter :: exit_code_general_error = 170
+  integer, parameter :: exit_code_input_error = 171
+  integer, parameter :: exit_code_open_file = 172
+  integer, parameter :: exit_code_failed_to_converge = 173
+
+end module exit_codes

--- a/getinp.f90
+++ b/getinp.f90
@@ -8,6 +8,7 @@
 
 subroutine getinp()
 
+  use exit_codes
   use sizes
   use compute_data, only : ntype, natoms, idfirst, nmols, ityperest, coor, restpars
   use input
@@ -199,12 +200,12 @@ subroutine getinp()
              keyword(i,1) /= 'segid' .and. &
              keyword(i,1) /= 'chkgrad' ) then
       write(*,*) ' ERROR: Keyword not recognized: ', trim(keyword(i,1))
-      stop
+      stop exit_code_input_error
     end if
   end do
   if ( ioerr /= 0 ) then
     write(*,*) ' ERROR: Some optional keyword was not used correctly: ', trim(keyword(i,1))
-    stop
+    stop exit_code_input_error
   end if
   write(*,*) ' Seed for random number generator: ', seed
   call init_random_number(seed)
@@ -220,7 +221,7 @@ subroutine getinp()
   end do
   if(xyzout(1:4) == '####') then
     write(*,*)' ERROR: Output file not (correctly?) specified. '
-    stop
+    stop exit_code_input_error
   end if
   write(*,*)' Output file: ', trim(adjustl(xyzout))
 
@@ -271,7 +272,7 @@ subroutine getinp()
               write(*,*) ' Standard PDB format specifications', &
                          ' can be found at: '
               write(*,*) ' www.rcsb.org/pdb '
-              stop
+              stop exit_code_input_error
             end if
            
             ! This only tests if residue numbers can be read, they are used 
@@ -288,7 +289,7 @@ subroutine getinp()
               write(*,*) ' Standard PDB format specifications',&
                          ' can be found at: '
               write(*,*) ' www.rcsb.org/pdb '
-              stop
+              stop exit_code_input_error
             end if   
           end if
           read(10,str_format,iostat=ioerr) record
@@ -306,14 +307,14 @@ subroutine getinp()
             if(ioerr /= 0) then
               write(*,*) " ERROR: Could not read atom index from CONECT line: "
               write(*,*) trim(adjustl(record))
-              stop
+              stop exit_code_input_error
             end if
             iread = iread + 5
             read(record(iread:iread+4),*,iostat=ioerr) nconnect(idatom,1)
             if(ioerr /= 0) then
               write(*,*) " ERROR: Could not read any connection index from CONECT line: "
               write(*,*) trim(adjustl(record))
-              stop
+              stop exit_code_input_error
             end if
             nconnect(idatom,1) = nconnect(idatom,1) - idfirstatom + 1
             maxcon(idatom) = 1
@@ -680,7 +681,7 @@ subroutine getinp()
 
     if ( ioerr /= 0 ) then
       write(*,*) ' ERROR: Some restriction is not set correctly. '
-      stop
+      stop exit_code_input_error
     end if
 
   end do
@@ -696,14 +697,14 @@ subroutine getinp()
       read(keyword(iline,2),*,iostat=ioerr) dism
       if ( ioerr /= 0 ) then
         write(*,*) ' ERROR: Failed reading tolerance. '
-        stop
+        stop exit_code_input_error
       end if
       exit
     end if
   end do
   if ( ioerr /= 0 ) then
     write(*,*) ' ERROR: Overall tolerance not set. Use, for example: tolerance 2.0 '
-    stop
+    stop exit_code_input_error
   end if
   write(*,*) ' Distance tolerance: ', dism
 
@@ -717,11 +718,11 @@ subroutine getinp()
       read(keyword(iline,2),*,iostat=ioerr) short_tol_dist
       if ( ioerr /= 0 ) then
         write(*,*) ' ERROR: Failed reading short_tol_dist. '
-        stop
+        stop exit_code_input_error
       end if
       if ( short_tol_dist > dism ) then 
         write(*,*) ' ERROR: The short_tol_dist parameter must be smaller than the tolerance. '
-        stop
+        stop exit_code_input_error
       end if
       write(*,*) ' User defined short tolerance distance: ', short_tol_dist
       short_tol_dist = short_tol_dist**2
@@ -735,11 +736,11 @@ subroutine getinp()
       read(keyword(iline,2),*,iostat=ioerr) short_tol_scale
       if ( ioerr /= 0 ) then
         write(*,*) ' ERROR: Failed reading short_tol_scale. '
-        stop
+        stop exit_code_input_error
       end if
       if ( short_tol_dist <= 0.d0 ) then 
         write(*,*) ' ERROR: The short_tol_scale parameter must be positive. '
-        stop
+        stop exit_code_input_error
       end if
       write(*,*) ' User defined short tolerance scale: ', short_tol_scale
       exit
@@ -761,7 +762,7 @@ subroutine getinp()
         if(keyword(iline,1) == 'structure'.or.&
            iline == nlines) then
           write(*,*) ' ERROR: Structure specification not ending with "end structure"'
-          stop
+          stop exit_code_input_error
         end if
         iline = iline + 1
       end do
@@ -830,7 +831,7 @@ subroutine getinp()
       if ( chain(itype) /= "#" .and. changechains(itype) ) then
         write(*,*) " ERROR: 'changechains' and 'chain' input parameters are not compatible "
         write(*,*) "        for a single structure. "
-        stop
+        stop exit_code_input_error
       end if
     end do
   end if
@@ -874,7 +875,7 @@ subroutine getinp()
         restart_from(0) = keyword(iline,2)
       else
         write(*,*) ' ERROR: More than one definition of restart_from file for all system. '
-        stop
+        stop exit_code_input_error
       end if
     end if
     if ( keyword(iline,1) == 'restart_to' ) then
@@ -889,7 +890,7 @@ subroutine getinp()
         restart_to(0) = keyword(iline,2)
       else
         write(*,*) ' ERROR: More than one definition of restart_to file for all system. '
-        stop
+        stop exit_code_input_error
       end if
     end if
   end do lines
@@ -902,6 +903,7 @@ end subroutine getinp
 !
 
 subroutine failopen(record)
+  use exit_codes
   use sizes
   character(len=strl) :: record
   write(*,*) 
@@ -911,7 +913,7 @@ subroutine failopen(record)
   write(*,*) '        files are in the current directory or if the' 
   write(*,*) '        correct paths are provided.'
   write(*,*) 
-  stop 
+  stop exit_code_open_file
 end subroutine failopen
 
 !

--- a/initial.f90
+++ b/initial.f90
@@ -9,6 +9,7 @@
 
 subroutine initial(n,x)
 
+  use exit_codes
   use sizes
   use compute_data
   use input, only : randini, ntfix, fix, moldy, chkgrad, avoidoverlap,&
@@ -238,7 +239,7 @@ subroutine initial(n,x)
       end if
         write(*,*) ' >The maximum number of cycles (',nloop0_type(itype),') was achieved.' 
         write(*,*) '  You may try increasing it with the',' nloop0 keyword, as in: nloop0 1000 '
-      stop
+      stop exit_code_failed_to_converge
     end if
   end do
   init1 = .false.
@@ -364,7 +365,7 @@ subroutine initial(n,x)
                               x(ilugan+1), x(ilugan+2), x(ilugan+3)
       if ( ioerr /= 0 ) then
         write(*,*) ' ERROR: Could not read restart file: ', trim(adjustl(record))
-        stop
+        stop exit_code_open_file
       end if
       ilubar = ilubar + 3
       ilugan = ilugan + 3
@@ -516,14 +517,14 @@ subroutine initial(n,x)
       open(10,file=record,status='old',action='read',iostat=ioerr)
       if ( ioerr /= 0 ) then
         write(*,*) ' ERROR: Could not open restart file: ', trim(adjustl(record))
-        stop
+        stop exit_code_open_file
       end if
       do i = 1, nmols(itype)
         read(10,*,iostat=ioerr) x(ilubar+1), x(ilubar+2), x(ilubar+3), &
                                 x(ilugan+1), x(ilugan+2), x(ilugan+3)
         if ( ioerr /= 0 ) then
           write(*,*) ' ERROR: Could not read restart file: ', trim(adjustl(record))
-          stop
+          stop exit_code_open_file
         end if
         ilubar = ilubar + 3
         ilugan = ilugan + 3

--- a/output.f90
+++ b/output.f90
@@ -8,6 +8,7 @@
 
 subroutine output(n,x)
 
+  use exit_codes
   use sizes
   use compute_data
   use input
@@ -52,7 +53,7 @@ subroutine output(n,x)
     open(10,file=restart_to(0),iostat=ioerr)
     if ( ioerr /= 0 ) then
       write(*,*) ' ERROR: Could not open restart_to file: ', trim(adjustl(record))
-      stop
+      stop exit_code_open_file
     end if
     ilubar = 0
     ilugan = ntotmol*3
@@ -76,7 +77,7 @@ subroutine output(n,x)
       open(10,file=record,iostat=ioerr)
       if ( ioerr /= 0 ) then
         write(*,*) ' ERROR: Could not open restart_to file: ', trim(adjustl(record))
-        stop
+        stop exit_code_open_file
       end if
       do i = 1, nmols(itype)
         write(10,"(6(tr1,es23.16))") x(ilubar+1), x(ilubar+2), x(ilubar+3), &
@@ -412,7 +413,7 @@ subroutine output(n,x)
               write(*,*) ' Standard PDB format specifications can',&
                          ' be found at: '
               write(*,*) ' www.rcsb.org/pdb '
-              stop
+              stop exit_code_input_error
             end if
             if ( ifres .eq. 0 ) ifres = imark
             ilres = imark
@@ -558,7 +559,7 @@ subroutine output(n,x)
               write(*,*) ' Standard PDB format specifications can',&
                          ' be found at: '
               write(*,*) ' www.rcsb.org/pdb '
-              stop
+              stop exit_code_input_error
             end if
             if ( ifres .eq. 0 ) ifres = imark
             ilres = imark

--- a/packmol.f90
+++ b/packmol.f90
@@ -33,6 +33,7 @@
 
 program packmol
 
+  use exit_codes
   use sizes
   use compute_data
   use input
@@ -51,6 +52,7 @@ program packmol
   integer :: resntemp, nloop_tmp
   integer :: ioerr
   integer :: maxmove_tmp
+  integer :: exit_code = 0
       
   double precision, allocatable :: x(:), xprint(:) ! (nn)
   double precision :: v1(3),v2(3),v3(3)
@@ -146,13 +148,13 @@ program packmol
           if(nmols(itype).gt.1) then
             write(*,*)' ERROR: Cannot set number > 1',' for fixed molecules. '
             write(*,*) '       Structure: ', itype,': ', trim(adjustl(record))
-            stop
+            stop exit_code_input_error
           end if
           if ( restart_from(itype) /= 'none' .or. &
                restart_to(itype) /= 'none' ) then
             write(*,*) ' ERROR: Restart files cannot be used for fixed molecules. '
             write(*,*) '        Structure: ', itype,': ', trim(adjustl(record))
-            stop
+            stop exit_code_input_error
           end if
         end if
       end do
@@ -300,7 +302,7 @@ program packmol
               if ( ioerr /= 0 ) then
                 if ( iiatom == -1 ) then 
                   write(*,*) ' ERROR: Could not read atom selection for type: ', itype
-                  stop
+                  stop exit_code_input_error
                 else
                   exit
                 end if
@@ -308,7 +310,7 @@ program packmol
               if ( iiatom > natoms(itype) ) then
                 write(*,*) ' ERROR: atom selection with index greater than number of '
                 write(*,*) '        atoms in structure ', itype
-                stop
+                stop exit_code_input_error
               end if
               if(iatom.eq.iiatom) exit
             end do
@@ -349,7 +351,7 @@ program packmol
       if(.not.rests) then
         write(*,*) ' ERROR: Some molecule has no geometrical',&
                    ' restriction defined: nothing to do.'
-        stop
+        stop exit_code_input_error
       end if
     end do
   end do
@@ -406,7 +408,7 @@ program packmol
                keyword(iline,2) /= 'y' .and. &
                keyword(iline,2) /= 'z' ) then
             write(*,*) ' ERROR: constrain_rotation option not properly defined (not x, y, or z) '
-            stop
+            stop exit_code_input_error
           end if
         end if
       end if
@@ -454,7 +456,7 @@ program packmol
           read(keyword(iline,2),*,iostat=ioerr) value
           if ( ioerr /= 0 ) then
             write(*,*) ' ERROR: Could not read radius from keyword. '
-            stop
+            stop exit_code_input_error
           end if
           iicart = icart
           do imol = 1, nmols(itype)
@@ -471,7 +473,7 @@ program packmol
           read(keyword(iline,2),*,iostat=ioerr) value
           if ( ioerr /= 0 ) then
             write(*,*) ' ERROR: Could not read fscale value from keyword. '
-            stop
+            stop exit_code_input_error
           end if
           iicart = icart
           do imol = 1, nmols(itype)
@@ -488,7 +490,7 @@ program packmol
           read(keyword(iline,2),*,iostat=ioerr) value
           if ( ioerr /= 0 ) then
             write(*,*) ' ERROR: Could not read short_radius value from keyword. '
-            stop
+            stop exit_code_input_error
           end if
           iicart = icart
           do imol = 1, nmols(itype)
@@ -506,7 +508,7 @@ program packmol
           read(keyword(iline,2),*,iostat=ioerr) value
           if ( ioerr /= 0 ) then
             write(*,*) ' ERROR: Could not read short_radius_scale value from keyword. '
-            stop
+            stop exit_code_input_error
           end if
           iicart = icart
           do imol = 1, nmols(itype)
@@ -550,7 +552,7 @@ program packmol
           read(keyword(iline,2),*,iostat=ioerr) value
           if ( ioerr /= 0 ) then
             write(*,*) ' ERROR: Could not read radius from keyword. '
-            stop
+            stop exit_code_input_error
           end if
           ival = 2
           do
@@ -559,7 +561,7 @@ program packmol
             if ( iat > natoms(itype) ) then
               write(*,*) ' ERROR: atom selection with index greater than number of '
               write(*,*) '        atoms in structure ', itype
-              stop
+              stop exit_code_input_error
             end if
             radius(icart+iat) = value
             ival = ival + 1
@@ -572,7 +574,7 @@ program packmol
           read(keyword(iline,2),*,iostat=ioerr) value
           if ( ioerr /= 0 ) then
             write(*,*) ' ERROR: Could not read fscale value from keyword. '
-            stop
+            stop exit_code_input_error
           end if
           ival = 2
           do
@@ -581,7 +583,7 @@ program packmol
             if ( iat > natoms(itype) ) then
               write(*,*) ' ERROR: atom selection with index greater than number of '
               write(*,*) '        atoms in structure ', itype
-              stop
+              stop exit_code_input_error
             end if
             fscale(icart+iat) = value
             ival = ival + 1
@@ -594,7 +596,7 @@ program packmol
           read(keyword(iline,2),*,iostat=ioerr) value
           if ( ioerr /= 0 ) then
             write(*,*) ' ERROR: Could not read short_radius value from keyword. '
-            stop
+            stop exit_code_input_error
           end if
           ival = 2
           do
@@ -603,7 +605,7 @@ program packmol
             if ( iat > natoms(itype) ) then
               write(*,*) ' ERROR: atom selection with index greater than number of '
               write(*,*) '        atoms in structure ', itype
-              stop
+              stop exit_code_input_error
             end if
             short_radius(icart+iat) = value
             use_short_radius(icart+iat) = .true.
@@ -617,7 +619,7 @@ program packmol
           read(keyword(iline,2),*,iostat=ioerr) value
           if ( ioerr /= 0 ) then
             write(*,*) ' ERROR: Could not read short_radius_scale value from keyword. '
-            stop
+            stop exit_code_input_error
           end if
           ival = 2
           do
@@ -626,7 +628,7 @@ program packmol
             if ( iat > natoms(itype) ) then
               write(*,*) ' ERROR: atom selection with index greater than number of '
               write(*,*) '        atoms in structure ', itype
-              stop
+              stop exit_code_input_error
             end if
             short_radius_scale(icart+iat) = value
             use_short_radius(icart+iat) = .true.
@@ -658,7 +660,7 @@ program packmol
      if ( short_radius(i) >= radius(i) ) then 
        write(*,*) ' ERROR: The short radius must be smaller than the default radius. '
        write(*,*) '        (the default radius is one half of the default tolerance).'
-       stop
+       stop exit_code_input_error
      end if
    end if
   end do
@@ -674,7 +676,7 @@ program packmol
     write(*,*) ' Wrote output file: ', trim(adjustl(xyzout))
     if ( crd ) write(*,*) ' ... and to CRD file: ', trim(adjustl(crdfile))
     write(*,dash1_line)
-    stop
+    stop exit_code_input_error
   end if
   
   !
@@ -925,6 +927,7 @@ program packmol
           if ( itype .eq. ntype+1 ) then
             write(*,*)' STOP: Maximum number of GENCAN loops achieved.'
             call checkpoint(n,xprint)
+            exit_code = exit_code_failed_to_converge
             exit main
           else
             write(*,*)' Maximum number of GENCAN loops achieved.'
@@ -940,6 +943,15 @@ program packmol
   write(*,*) '  Running time: ', etime(tarray) - time0,' seconds. ' 
   write(*,dash3_line)
   write(*,*) 
+
+  ! Fortran < 2008 doesn't support non-constant exit codes
+  if (exit_code == 0) then
+    stop
+  elseif (exit_code == exit_code_failed_to_converge) then
+    stop exit_code_failed_to_converge
+  else
+    stop exit_code_general_error
+  end if
 
 end program packmol
 

--- a/setsizes.f90
+++ b/setsizes.f90
@@ -8,6 +8,7 @@
 
 subroutine setsizes()
 
+  use exit_codes
   use sizes
   use compute_data
   use input
@@ -145,7 +146,7 @@ subroutine setsizes()
       read(record,*,iostat=ioerr) fbins
       if ( ioerr /= 0 ) then
         write(*,*) ' ERROR: Invalid value for fbins. '
-        stop
+        stop exit_code_input_error
       end if
     end if
   end do
@@ -164,7 +165,7 @@ subroutine setsizes()
       if ( keyword(iline,2) == "none" ) then
         write(*,*) ' ERROR: structure without filename. '
         write(*,*) ' The syntax must be, for example: structure water.pdb '
-        stop 
+        stop exit_code_input_error 
       end if
     end if
   end do
@@ -237,11 +238,11 @@ subroutine setsizes()
       read(keyword(iline,2),*,iostat=ioerr) nmols(itype)
       if ( ioerr /= 0 ) then
         write(*,*) ' ERROR: Error reading number of molecules of type ', itype
-        stop  
+        stop exit_code_input_error  
       end if
       if ( nmols(itype) < 1 ) then
         write(*,*) ' ERROR: Number of molecules of type ', itype, ' set to less than 1 '
-        stop
+        stop exit_code_input_error
       end if
     end if
 
@@ -252,11 +253,11 @@ subroutine setsizes()
         read(keyword(iline,2),*,iostat=ioerr) nloop_type(itype)
         if ( ioerr /= 0 ) then
           write(*,*) ' ERROR: Error reading number of loops of type ', itype
-          stop  
+          stop exit_code_input_error
         end if
         if ( nloop_type(itype) < 1 ) then
           write(*,*) ' ERROR: Number of loops of type ', itype, ' set to less than 1 '
-          stop
+          stop exit_code_input_error
         end if
       end if
     end if 
@@ -268,11 +269,11 @@ subroutine setsizes()
         read(keyword(iline,2),*,iostat=ioerr) nloop0_type(itype)
         if ( ioerr /= 0 ) then
           write(*,*) ' ERROR: Error reading number of loops-0 of type ', itype
-          stop  
+          stop exit_code_input_error
         end if
         if ( nloop0_type(itype) < 1 ) then
           write(*,*) ' ERROR: Number of loops-0 of type ', itype, ' set to less than 1 '
-          stop
+          stop exit_code_input_error
         end if
       end if
     end if 

--- a/strlength.f90
+++ b/strlength.f90
@@ -61,6 +61,7 @@ function alltospace(record)
 end function alltospace
 
 subroutine parse_spaces(record)
+  use exit_codes
   use input, only : forbidden_char
   use sizes
   implicit none
@@ -76,7 +77,7 @@ subroutine parse_spaces(record)
         i = i + 1
         if( i > strlength(record) ) then
           write(*,*) ' ERROR: Could not find ending quotes in line: ', trim(record)
-          stop
+          stop exit_code_input_error
         end if
         if(record(i:i) == " ") then
           record(i:i) = forbidden_char 


### PR DESCRIPTION
Added exit_codes module. Using constants from it to set non-zero error codes on failures.
Fixes https://github.com/m3g/packmol/issues/28