### PR TITLE
fix: fix compilation reference missing issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ setsizes.o : setsizes.f90 $(modules)
 	@$(FORTRAN) $(FLAGS) -c setsizes.f90
 getinp.o : getinp.f90  $(modules)
 	@$(FORTRAN) $(FLAGS) -c getinp.f90
-strlength.o : strlength.f90  
+strlength.o : strlength.f90  $(modules)
 	@$(FORTRAN) $(FLAGS) -c strlength.f90
 output.o : output.f90  $(modules)
 	@$(FORTRAN) $(FLAGS) -c output.f90


### PR DESCRIPTION
relates to https://github.com/Homebrew/homebrew-core/pull/116766

build error

```
  ==> make
  strlength.f90:11:7:
  
     11 |   use sizes
        |       1
  Fatal Error: Cannot open module file 'sizes.mod' for reading at (1): No such file or directory
  compilation terminated.
```