### PR TITLE
add Xygauss surface

### DIFF
--- a/src/comprest.f90
+++ b/src/comprest.f90
@@ -161,6 +161,23 @@ subroutine comprest(icart,f)
            dmin1(-w , 0.d0)**2 * &
            dmin1(w - restpars(irest,9), 0.d0)**2 * &
            dmin1(d - restpars(irest,7)**2 , 0.d0 )**2 )
+    else if(ityperest(irest).eq.14) then
+      w = restpars(irest,6)*exp( &
+          -(xcart(icart,1) - restpars(irest,1))**2 &
+          /(2*restpars(irest,3)**2) &
+          -(xcart(icart,2) - restpars(irest,2))**2 &
+          /(2*restpars(irest,4)**2)) &
+          -(xcart(icart,3)-restpars(irest,5))
+      a1 = dmax1(w,0.d0)
+      f = f + scale * a1*a1
+    else if(ityperest(irest).eq.15) then
+      w = restpars(irest,6)*exp( &
+          -(xcart(icart,1) - restpars(irest,1))**2 &
+          /(2*restpars(irest,3)**2) &
+          -(xcart(icart,2) - restpars(irest,2))**2 &
+          /(2*restpars(irest,4)**2)) &
+          -(xcart(icart,3)-restpars(irest,5))
+      a1 = dmin1(w,0.d0)
     end if 
   end do 
   return

--- a/src/comprest.f90
+++ b/src/comprest.f90
@@ -178,6 +178,7 @@ subroutine comprest(icart,f)
           /(2*restpars(irest,4)**2)) &
           -(xcart(icart,3)-restpars(irest,5))
       a1 = dmin1(w,0.d0)
+      f = f + scale * a1*a1
     end if 
   end do 
   return

--- a/src/getinp.f90
+++ b/src/getinp.f90
@@ -665,7 +665,6 @@ subroutine getinp()
     if(keyword(iline,1).eq.'over' .or. keyword(iline,1).eq.'above') then
       irest = irest + 1
       irestline(irest) = iline
-      ityperest(irest) = 10
       read(keyword(iline,3),*,iostat=ioerr) restpars(irest,1)
       read(keyword(iline,4),*,iostat=ioerr) restpars(irest,2)
       read(keyword(iline,5),*,iostat=ioerr) restpars(irest,3)
@@ -684,7 +683,6 @@ subroutine getinp()
     if(keyword(iline,1).eq.'below') then
       irest = irest + 1
       irestline(irest) = iline
-      ityperest(irest) = 11
       read(keyword(iline,3),*,iostat=ioerr) restpars(irest,1)
       read(keyword(iline,4),*,iostat=ioerr) restpars(irest,2)
       read(keyword(iline,5),*,iostat=ioerr) restpars(irest,3)

--- a/src/getinp.f90
+++ b/src/getinp.f90
@@ -670,7 +670,15 @@ subroutine getinp()
       read(keyword(iline,4),*,iostat=ioerr) restpars(irest,2)
       read(keyword(iline,5),*,iostat=ioerr) restpars(irest,3)
       read(keyword(iline,6),*,iostat=ioerr) restpars(irest,4)
-      if(keyword(iline,2).ne.'plane') ioerr = 1
+      if (keyword(iline,2).eq.'plane') then
+        ityperest(irest) = 10
+      else if(keyword(iline,2).eq.'xygauss') then
+        ityperest(irest) = 14
+        read(keyword(iline,7),*,iostat=ioerr) restpars(irest,5)
+        read(keyword(iline,8),*,iostat=ioerr) restpars(irest,6)
+      else 
+        ioerr = 1
+      end if
     end if
 
     if(keyword(iline,1).eq.'below') then
@@ -681,7 +689,15 @@ subroutine getinp()
       read(keyword(iline,4),*,iostat=ioerr) restpars(irest,2)
       read(keyword(iline,5),*,iostat=ioerr) restpars(irest,3)
       read(keyword(iline,6),*,iostat=ioerr) restpars(irest,4)
-      if(keyword(iline,2).ne.'plane') ioerr = 1 
+      if (keyword(iline,2).eq.'plane') then
+        ityperest(irest) = 11
+      else if(keyword(iline,2).eq.'xygauss') then
+        ityperest(irest) = 15
+        read(keyword(iline,7),*,iostat=ioerr) restpars(irest,5)
+        read(keyword(iline,8),*,iostat=ioerr) restpars(irest,6)
+      else 
+        ioerr = 1
+      end if
     end if
 
     if ( ioerr /= 0 ) then

--- a/src/gwalls.f90
+++ b/src/gwalls.f90
@@ -257,8 +257,41 @@ subroutine gwalls(icart,irest)
     gxcar(icart,1) = gxcar(icart,1) + rg(1)
     gxcar(icart,2) = gxcar(icart,2) + rg(2)
     gxcar(icart,3) = gxcar(icart,3) + rg(3)
+
+  ! Addition of Gaussian surface on xy plane
+  ! Based on eq. of type h*exp(-(x-a)**2/2c**2 -(y-b)**2/2d**2)-(z-g)  
+  else if(ityperest(irest).eq.14) then
+    d = restpars(irest,6)*exp( & 
+        -(xcart(icart,1) - restpars(irest,1))**2 &
+        /(2*restpars(irest,3)**2) &
+        -(xcart(icart,2) - restpars(irest,2))**2 &
+        /(2*restpars(irest,4)**2)) &
+        -(xcart(icart,3)-restpars(irest,5))
+    if(d.gt.0.d0) then
+      d = scale * d
+      gxcar(icart,1) = gxcar(icart,1) - 2.d0*d*(xcart(icart,1)-restpars(irest,1)) &
+      * (d+(xcart(icart,3)-restpars(irest,5))) / restpars(irest,3)**2 
+      gxcar(icart,2) = gxcar(icart,2) - 2.d0*d*(xcart(icart,2)-restpars(irest,2)) &
+      * (d+(xcart(icart,3)-restpars(irest,5))) / restpars(irest,4)**2 
+      gxcar(icart,3) = gxcar(icart,3) - 2.d0*d
+    end if
+  else if(ityperest(irest).eq.15) then
+    d = restpars(irest,6)*exp( &
+        -(xcart(icart,1) - restpars(irest,1))**2 &
+        /(2*restpars(irest,3)**2) &
+        -(xcart(icart,2) - restpars(irest,2))**2 &
+        /(2*restpars(irest,4)**2)) &
+        -(xcart(icart,3)-restpars(irest,5))
+    if(d.lt.0.d0) then
+      d = scale * d
+      gxcar(icart,1) = gxcar(icart,1) - 2.d0*d*(xcart(icart,1)-restpars(irest,1)) &
+      * (d+(xcart(icart,3)-restpars(irest,5))) / restpars(irest,3)**2
+      gxcar(icart,2) = gxcar(icart,2) - 2.d0*d*(xcart(icart,2)-restpars(irest,2)) &
+      * (d+(xcart(icart,3)-restpars(irest,5))) / restpars(irest,4)**2 
+      gxcar(icart,3) = gxcar(icart,3) - 2.d0*d
+    end if
   end if
-      
+
   return 
 end subroutine gwalls
 


### PR DESCRIPTION

@sschott

I merged the changes here, and now you can clone the repo and checkout this branch. 

The package compiles. Can you give some simple example of the usage of this constraint, so I can add to the tests?

I have tested this:

```
filetype pdb
output xzgauss.pdb

tolerance 2.0

structure CLA.pdb
    number 50
    inside box -50 -50 -50 50 50 50
    over xygauss 21.0 5.0 10.0 20.0 -23.0 15.0
end structure
```

where CLA.pdb is:

```
HEADER
HETATM    1 CLA  CLA    2        0.000   0.000   0.000
```

but I got this error:

```
Program received signal SIGFPE: Floating-point exception - erroneous arithmetic operation.

Backtrace for this error:
#0  0x7f2d132c1ad0 in ???
#1  0x7f2d132c0c35 in ???
#2  0x7f2d12fd151f in ???
        at ./signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c:0
#3  0x7f2d13227a00 in xflow
        at ../sysdeps/ieee754/dbl-64/math_err.c:40
#4  0x7f2d131eef02 in __GI___exp
        at ./w_exp_template.c:32
#5  0x559bef155cbd in comprest_
        at src/comprest.f90:170
#6  0x559bef17703d in computef_
        at src/computef.f90:78
#7  0x559bef0df8c4 in initial_
        at src/initial.f90:211
#8  0x559bef168e61 in packmol
        at app/packmol.f90:686
#9  0x559bef16bd6a in main
        at app/packmol.f90:36
Floating point exception (core dumped)
```

Is there some parameter missing in the example of the xygauss surface? Or do you see any other obvious problem?
