### PR TITLE
Capture of floating point exception

### DIFF
--- a/src/comprest.f90
+++ b/src/comprest.f90
@@ -162,21 +162,23 @@ subroutine comprest(icart,f)
            dmin1(w - restpars(irest,9), 0.d0)**2 * &
            dmin1(d - restpars(irest,7)**2 , 0.d0 )**2 )
     else if(ityperest(irest).eq.14) then
-      w = restpars(irest,6)*exp( &
-          -(xcart(icart,1) - restpars(irest,1))**2 &
-          /(2*restpars(irest,3)**2) &
-          -(xcart(icart,2) - restpars(irest,2))**2 &
-          /(2*restpars(irest,4)**2)) &
-          -(xcart(icart,3)-restpars(irest,5))
+      a1 = -(xcart(icart,1) - restpars(irest,1))**2/(2*restpars(irest,3)**2)
+      a2 = -(xcart(icart,2) - restpars(irest,2))**2/(2*restpars(irest,4)**2)
+      if(a1+a2<=-50) then
+        w = -(xcart(icart,3)-restpars(irest,5))
+      else
+        w = restpars(irest,6)*exp(a1+a2)-(xcart(icart,3)-restpars(irest,5))
+      end if
       a1 = dmax1(w,0.d0)
       f = f + scale * a1*a1
     else if(ityperest(irest).eq.15) then
-      w = restpars(irest,6)*exp( &
-          -(xcart(icart,1) - restpars(irest,1))**2 &
-          /(2*restpars(irest,3)**2) &
-          -(xcart(icart,2) - restpars(irest,2))**2 &
-          /(2*restpars(irest,4)**2)) &
-          -(xcart(icart,3)-restpars(irest,5))
+      a1 = -(xcart(icart,1) - restpars(irest,1))**2/(2*restpars(irest,3)**2)
+      a2 = -(xcart(icart,2) - restpars(irest,2))**2/(2*restpars(irest,4)**2)
+      if(a1+a2<=-50) then
+        w = -(xcart(icart,3)-restpars(irest,5))
+      else
+        w = restpars(irest,6)*exp(a1+a2)-(xcart(icart,3)-restpars(irest,5))
+      end if
       a1 = dmin1(w,0.d0)
       f = f + scale * a1*a1
     end if 

--- a/src/comprest.f90
+++ b/src/comprest.f90
@@ -1,8 +1,8 @@
-!  
+!
 !  Written by Leandro Martínez, 2009-2011.
 !  Copyright (c) 2009-2018, Leandro Martínez, Jose Mario Martinez,
 !  Ernesto G. Birgin.
-!  
+!
 !
 ! Subroutine comprest: Compute the function value relative to
 !                      to the restrictions for one atom
@@ -14,7 +14,7 @@ subroutine comprest(icart,f)
   use compute_data, only : xcart, restpars, scale, scale2, nratom, ityperest, iratom
 
   implicit none
-  integer :: iratcount, irest, icart 
+  integer :: iratcount, irest, icart
   double precision :: xmin, ymin, zmin, clength, a1, a2, a3, a4, w, b1, b2, b3, d, a5, a6
   double precision :: f
   double precision :: xmax, ymax, zmax
@@ -35,11 +35,11 @@ subroutine comprest(icart,f)
       a1 = dmin1(xcart(icart,1) - xmin, 0.d0)
       a2 = dmin1(xcart(icart,2) - ymin, 0.d0)
       a3 = dmin1(xcart(icart,3) - zmin, 0.d0)
-      f = f + scale*(a1 * a1 + a2 * a2 + a3 * a3) 
+      f = f + scale*(a1 * a1 + a2 * a2 + a3 * a3)
       a1 = dmax1(xcart(icart,1) - xmax, 0.d0)
       a2 = dmax1(xcart(icart,2) - ymax, 0.d0)
       a3 = dmax1(xcart(icart,3) - zmax, 0.d0)
-      f = f + scale*(a1 * a1 + a2 * a2 + a3 * a3)   
+      f = f + scale*(a1 * a1 + a2 * a2 + a3 * a3)
     else if(ityperest(irest).eq.3) then
       xmin = restpars(irest,1)
       ymin = restpars(irest,2)
@@ -50,12 +50,12 @@ subroutine comprest(icart,f)
       a1 = dmin1(xcart(icart,1) - xmin, 0.d0)
       a2 = dmin1(xcart(icart,2) - ymin, 0.d0)
       a3 = dmin1(xcart(icart,3) - zmin, 0.d0)
-      f = f + scale*(a1 * a1 + a2 * a2 + a3 * a3) 
+      f = f + scale*(a1 * a1 + a2 * a2 + a3 * a3)
       a1 = dmax1(xcart(icart,1) - xmax, 0.d0)
       a2 = dmax1(xcart(icart,2) - ymax, 0.d0)
       a3 = dmax1(xcart(icart,3) - zmax, 0.d0)
-      f = f + scale*(a1 * a1 + a2 * a2 + a3 * a3)   
-    else if(ityperest(irest).eq.4) then     
+      f = f + scale*(a1 * a1 + a2 * a2 + a3 * a3)
+    else if(ityperest(irest).eq.4) then
       w = (xcart(icart,1)-restpars(irest,1))**2 + &
           (xcart(icart,2)-restpars(irest,2))**2 + &
           (xcart(icart,3)-restpars(irest,3))**2 - &
@@ -185,4 +185,3 @@ subroutine comprest(icart,f)
   end do 
   return
 end subroutine comprest
-

--- a/src/getinp.f90
+++ b/src/getinp.f90
@@ -675,7 +675,7 @@ subroutine getinp()
         ityperest(irest) = 14
         read(keyword(iline,7),*,iostat=ioerr) restpars(irest,5)
         read(keyword(iline,8),*,iostat=ioerr) restpars(irest,6)
-      else 
+      else
         ioerr = 1
       end if
     end if

--- a/src/gwalls.f90
+++ b/src/gwalls.f90
@@ -261,12 +261,13 @@ subroutine gwalls(icart,irest)
   ! Addition of Gaussian surface on xy plane
   ! Based on eq. of type h*exp(-(x-a)**2/2c**2 -(y-b)**2/2d**2)-(z-g)  
   else if(ityperest(irest).eq.14) then
-    d = restpars(irest,6)*exp( & 
-        -(xcart(icart,1) - restpars(irest,1))**2 &
-        /(2*restpars(irest,3)**2) &
-        -(xcart(icart,2) - restpars(irest,2))**2 &
-        /(2*restpars(irest,4)**2)) &
-        -(xcart(icart,3)-restpars(irest,5))
+    a1 = -(xcart(icart,1) - restpars(irest,1))**2/(2*restpars(irest,3)**2)
+    a2 = -(xcart(icart,2) - restpars(irest,2))**2/(2*restpars(irest,4)**2)
+    if(a1+a2<=-50) then
+      d = -(xcart(icart,3)-restpars(irest,5))
+    else
+      d = restpars(irest,6)*exp(a1+a2)-(xcart(icart,3)-restpars(irest,5))
+    end if
     if(d.gt.0.d0) then
       d = scale * d
       gxcar(icart,1) = gxcar(icart,1) - 2.d0*d*(xcart(icart,1)-restpars(irest,1)) &
@@ -276,12 +277,13 @@ subroutine gwalls(icart,irest)
       gxcar(icart,3) = gxcar(icart,3) - 2.d0*d
     end if
   else if(ityperest(irest).eq.15) then
-    d = restpars(irest,6)*exp( &
-        -(xcart(icart,1) - restpars(irest,1))**2 &
-        /(2*restpars(irest,3)**2) &
-        -(xcart(icart,2) - restpars(irest,2))**2 &
-        /(2*restpars(irest,4)**2)) &
-        -(xcart(icart,3)-restpars(irest,5))
+    a1 = -(xcart(icart,1) - restpars(irest,1))**2/(2*restpars(irest,3)**2)
+    a2 = -(xcart(icart,2) - restpars(irest,2))**2/(2*restpars(irest,4)**2)
+    if(a1+a2<=-50) then
+      d = -(xcart(icart,3)-restpars(irest,5))
+    else
+      d = restpars(irest,6)*exp(a1+a2)-(xcart(icart,3)-restpars(irest,5))
+    end if
     if(d.lt.0.d0) then
       d = scale * d
       gxcar(icart,1) = gxcar(icart,1) - 2.d0*d*(xcart(icart,1)-restpars(irest,1)) &


### PR DESCRIPTION
With warnings enabled, Fortran gives an error if the argument of an exp is below ~-500, when getting close to 0. This is triggered in `h exp(−(x-a₁)²/(2a₂²)−(y-b₁)²/(2b₂²))-(z-c)=0`

Captured the exception by setting `h exp(−(x-a₁)²/(2a₂²)−(y-b₁)²/(2b₂²)) = 0` if `−(x-a₁)²/(2a₂²)−(y-b₁)²/(2b₂²) <= -50`