### PR TITLE
read repeated connectivity and print in the same CONECT line

### DIFF
--- a/src/output.f90
+++ b/src/output.f90
@@ -793,15 +793,9 @@ subroutine write_connect(iostream,idatom,iatom,ifirst)
    character(len=5) :: i5hex, tmp_i5hex
    character(len=strl) :: str
    if(maxcon(iatom+idatom) == 0) return
-   str = "CONECT"
-   j=7
    tmp_i5hex = i5hex(iatom+ifirst-1)
-   write(str(j:j+4),"(a5)") tmp_i5hex
-   do i = 1, maxcon(iatom+idatom)
-      j = j + 5
-      tmp_i5hex = i5hex(nconnect(iatom+idatom,i)+ifirst-1)
-      write(str(j:j+4),"(a5)") tmp_i5hex
-   end do
+   write(str,"(a7,9a5)") "CONECT", tmp_i5hex, & 
+       (i5hex(nconnect(iatom+idatom,i)+ifirst-1), i=1, maxcon(iatom+idatom))
    write(iostream,"(a)") trim(adjustl(str))
 end subroutine write_connect
 

--- a/src/output.f90
+++ b/src/output.f90
@@ -789,18 +789,33 @@ subroutine write_connect(iostream,idatom,iatom,ifirst)
    use sizes
    use input
    implicit none
-   integer :: i, j, iostream, iatom, idatom, ifirst
-   character(len=5) :: i5hex, tmp_i5hex
+   integer :: iostream, iatom, idatom, ifirst, iiat, icon
+   character(len=5) :: i5hex, idatom_i5hex, str_conat
    character(len=strl) :: str
-   if(maxcon(iatom+idatom) == 0) return
-   tmp_i5hex = i5hex(iatom+ifirst-1)
-   write(str,"(a7,9a5)") "CONECT", tmp_i5hex, & 
-       (i5hex(nconnect(iatom+idatom,i)+ifirst-1), i=1, maxcon(iatom+idatom))
-   write(iostream,"(a)") trim(adjustl(str))
+   iiat = iatom + idatom
+   if(maxcon(iiat) == 0) return
+   idatom_i5hex = i5hex(iatom+ifirst-1)
+   icon = 1
+   ! start CONECT line
+   write(str, "(a7,a5)") "CONECT", idatom_i5hex
+   do 
+      str_conat = i5hex(nconnect(iiat,icon)+ifirst-1)
+      ! finish CONECT line
+      if (icon >= maxcon(iiat)) then
+         write(str, "(a,a5)") trim(str), str_conat
+         write(iostream, "(a)") trim(adjustl(str))
+         exit
+      end if
+      ! Next atom in CONECT line (for a maximum of 4, must be in increasing order)
+      if (nconnect(iiat,icon+1) > nconnect(iiat,icon) .and. mod(icon,5) /= 0) then
+         write(str, "(a,a5)") trim(str), str_conat
+      else
+         ! finish connect line
+         write(str, "(a,a5)") trim(str), str_conat
+         write(iostream, "(a)") trim(adjustl(str))
+         ! Start a new CONECT line
+         write(str, "(a7,a5)") "CONECT", idatom_i5hex
+      end if
+      icon = icon + 1
+   end do
 end subroutine write_connect
-
-
-
-
-
-

--- a/testing/input_files/benzene2.inp
+++ b/testing/input_files/benzene2.inp
@@ -1,0 +1,12 @@
+#
+# A box with water
+#
+
+tolerance 2.0
+filetype pdb
+output output.pdb
+
+structure ./structure_files/benzene.pdb
+  number 2
+  inside box 0. 0. 0. 40. 40. 40.
+end structure

--- a/testing/output_files/benzene2.pdb
+++ b/testing/output_files/benzene2.pdb
@@ -1,0 +1,66 @@
+HEADER 
+TITLE     Built with Packmol                                             
+REMARK   Packmol generated pdb file 
+REMARK   Home-Page: http://m3g.iqm.unicamp.br/packmol
+REMARK
+HETATM    1  C1  UNK A   1     -39.360  23.796  22.066  1.00  0.00           C  
+HETATM    2  C2  UNK A   1     -38.440  24.256  21.130  1.00  0.00           C  
+HETATM    3  C3  UNK A   1     -37.561  23.367  20.524  1.00  0.00           C  
+HETATM    4  C4  UNK A   1     -37.601  22.018  20.852  1.00  0.00           C  
+HETATM    5  C5  UNK A   1     -38.521  21.557  21.787  1.00  0.00           C  
+HETATM    6  C6  UNK A   1     -39.400  22.447  22.394  1.00  0.00           C  
+HETATM    7  H1  UNK A   1     -40.044  24.489  22.537  1.00  0.00           H  
+HETATM    8  H2  UNK A   1     -38.409  25.308  20.875  1.00  0.00           H  
+HETATM    9  H3  UNK A   1     -36.845  23.726  19.797  1.00  0.00           H  
+HETATM   10  H4  UNK A   1     -36.917  21.325  20.381  1.00  0.00           H  
+HETATM   11  H5  UNK A   1     -38.552  20.506  22.043  1.00  0.00           H  
+HETATM   12  H6  UNK A   1     -40.116  22.088  23.122  1.00  0.00           H  
+HETATM   13  C1  UNK A   2     -30.840  16.391  30.181  1.00  0.00           C  
+HETATM   14  C2  UNK A   2     -31.469  17.570  30.566  1.00  0.00           C  
+HETATM   15  C3  UNK A   2     -31.842  18.505  29.607  1.00  0.00           C  
+HETATM   16  C4  UNK A   2     -31.585  18.262  28.264  1.00  0.00           C  
+HETATM   17  C5  UNK A   2     -30.957  17.084  27.878  1.00  0.00           C  
+HETATM   18  C6  UNK A   2     -30.584  16.149  28.837  1.00  0.00           C  
+HETATM   19  H1  UNK A   2     -30.551  15.664  30.927  1.00  0.00           H  
+HETATM   20  H2  UNK A   2     -31.669  17.759  31.613  1.00  0.00           H  
+HETATM   21  H3  UNK A   2     -32.331  19.422  29.908  1.00  0.00           H  
+HETATM   22  H4  UNK A   2     -31.875  18.989  27.517  1.00  0.00           H  
+HETATM   23  H5  UNK A   2     -30.757  16.895  26.831  1.00  0.00           H  
+HETATM   24  H6  UNK A   2     -30.094  15.232  28.536  1.00  0.00           H  
+CONECT    1    2    6    7
+CONECT    1    2
+CONECT    2    1    3    8
+CONECT    2    1
+CONECT    3    2    4    9
+CONECT    3    4
+CONECT    4    3    5   10
+CONECT    4    3
+CONECT    5    4    6   11
+CONECT    5    6
+CONECT    6    1    5   12
+CONECT    6    5
+CONECT    7    1
+CONECT    8    2
+CONECT    9    3
+CONECT   10    4
+CONECT   11    5
+CONECT   12    6
+CONECT   13   14   18   19
+CONECT   13   14
+CONECT   14   13   15   20
+CONECT   14   13
+CONECT   15   14   16   21
+CONECT   15   16
+CONECT   16   15   17   22
+CONECT   16   15
+CONECT   17   16   18   23
+CONECT   17   18
+CONECT   18   13   17   24
+CONECT   18   17
+CONECT   19   13
+CONECT   20   14
+CONECT   21   15
+CONECT   22   16
+CONECT   23   17
+CONECT   24   18
+END

--- a/testing/structure_files/benzene.pdb
+++ b/testing/structure_files/benzene.pdb
@@ -1,0 +1,34 @@
+TITLE     Structure1
+REMARK   4      COMPLIES WITH FORMAT V. 3.0, 1-DEC-2006
+REMARK 888
+HETATM    1  C1  UNK     0      -0.006   0.006  -0.062  1.00  0.00           C  
+HETATM    2  C2  UNK     0       0.033  -0.667  -1.278  1.00  0.00           C  
+HETATM    3  C3  UNK     0       0.066  -2.056  -1.303  1.00  0.00           C  
+HETATM    4  C4  UNK     0       0.061  -2.773  -0.113  1.00  0.00           C  
+HETATM    5  C5  UNK     0       0.022  -2.101   1.103  1.00  0.00           C  
+HETATM    6  C6  UNK     0      -0.011  -0.711   1.128  1.00  0.00           C  
+HETATM    7  H1  UNK     0      -0.032   1.087  -0.043  1.00  0.00           H  
+HETATM    8  H2  UNK     0       0.037  -0.108  -2.205  1.00  0.00           H  
+HETATM    9  H3  UNK     0       0.097  -2.579  -2.250  1.00  0.00           H  
+HETATM   10  H4  UNK     0       0.087  -3.854  -0.132  1.00  0.00           H  
+HETATM   11  H5  UNK     0       0.018  -2.659   2.030  1.00  0.00           H  
+HETATM   12  H6  UNK     0      -0.041  -0.188   2.075  1.00  0.00           H  
+CONECT    1    2    6    7
+CONECT    1    2
+CONECT    2    1    3    8
+CONECT    2    1
+CONECT    3    2    4    9
+CONECT    3    4
+CONECT    4    3    5   10
+CONECT    4    3
+CONECT    5    4    6   11
+CONECT    5    6
+CONECT    6    1    5   12
+CONECT    6    5
+CONECT    7    1
+CONECT    8    2
+CONECT    9    3
+CONECT   10    4
+CONECT   11    5
+CONECT   12    6
+END   

--- a/testing/test.sh
+++ b/testing/test.sh
@@ -22,3 +22,7 @@ julia runtests.jl ./input_files/water_box.inp \
 
 # check if output files are properly generated in a failed run
 ./test_failed.sh ./input_files/water_box_failed.inp packmol.log "FORCED" 
+
+# Test connectivity
+./test_connectivity.sh 
+

--- a/testing/test_connectivity.sh
+++ b/testing/test_connectivity.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+../packmol < ./input_files/benzene2.inp > /dev/null
+
+if diff <(grep "^CONECT" ./output.pdb) <(grep "^CONECT" ./output_files/benzene2.pdb) >/dev/null; then
+    exit 0  # Files are identical
+else
+    echo "Connectivity test failed."
+    exit 1  # Files are different
+fi


### PR DESCRIPTION
With this PR, repeated connectivity lines for the same atom are accumulated and the connectivity is not lost, but printed in the same output line. For instance, this connectivity:

```
CONECT    1    2    6    7
CONECT    1    2
CONECT    2    1    3    8
CONECT    2    1
```

will be printed in two lines, as:

```
CONECT    1    2    6    7    2
CONECT    2    1    3    8    1
```

This aims to fix https://github.com/m3g/packmol/issues/83 .

To do:

- Check if this is an acceptable solution.
- Add tests.