### PR TITLE
Update setup-fortran action

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: awvwgk/setup-fortran@main
+    - uses: fortran-lang/setup-fortran@main
       id: setup-fortran
       with:
         compiler: gcc


### PR DESCRIPTION
The setup-fortran action moved to the @fortran-lang org, my original repo will continue working, but it is recommended to change to the new repository.