### PR TITLE
Initialize maxmove input variable for all file types

### DIFF
--- a/src/getinp.f90
+++ b/src/getinp.f90
@@ -773,8 +773,13 @@ subroutine getinp()
       end if
    end do
 
-   ! Assigning the input lines that correspond to each structure
 
+   ! Default to all non-fixed molecules may be moved.
+   do itype = 1, ntype
+     maxmove(itype) = nmols(itype)
+   end do
+
+   ! Assigning the input lines that correspond to each structure
    itype = 0
    iline = 0
    do while(iline < nlines)
@@ -785,6 +790,9 @@ subroutine getinp()
          iline = iline + 1
          do while(keyword(iline,1).ne.'end'.or.&
             keyword(iline,2).ne.'structure')
+            if(keyword(iline,1).eq.'maxmove') then
+               read(keyword(iline,2),*) maxmove(itype)
+            end if
             if(keyword(iline,1) == 'structure'.or.&
                iline == nlines) then
                write(*,*) ' ERROR: Structure specification not ending with "end structure"'
@@ -806,15 +814,11 @@ subroutine getinp()
          changechains(itype) = .false.
          chain(itype) = "#"
          segid(itype) = ""
-         maxmove(itype) = nmols(itype)
          do iline = 1, nlines
             if(iline.gt.linestrut(itype,1).and.&
                iline.lt.linestrut(itype,2)) then
                if(keyword(iline,1).eq.'changechains') then
                   changechains(itype) = .true.
-               end if
-               if(keyword(iline,1).eq.'maxmove') then
-                  read(keyword(iline,2),*) maxmove(itype)
                end if
                if(keyword(iline,1).eq.'resnumbers') then
                   read(keyword(iline,2),*) resnumbers(itype)


### PR DESCRIPTION
## Problem

I noticed failures to converge when using input files in the xyz format, with output steps like:
```
--------------------------------------------------------------------------------

  Starting GENCAN loop:            2
  Scaling radii by:    1.0000000000000000

  Packing:|0                                                        100%|
          |***

  Function value from last GENCAN loop: f = .12819E+01
  Best function value before: f = .12819E+01
  Improvement from best function value:    -0.00 %
  Improvement from last loop:    -0.00 %
  Maximum violation of target distance:     0.199288
  Maximum violation of the constraints: .29794E+00
  All-type function value: .12819E+01
--------------------------------------------------------------------------------

  Moving worst molecules ...
  Function value before moving molecules:   1.2818851334743486
  Type         1 molecules with non-zero contributions:    3.52%
  Moving         0 molecules of type         1
  New positions will be based on good molecules (movebadrandom is not set)
   Moving:|0                                                        100%|
          ||
  Function value after moving molecules:   1.2818851334743486

--------------------------------------------------------------------------------

```
and no change in function value between steps.

The number of molecules to move is set in heuristics.F90:
` nmove = min0(maxmove(itype),max0(int(nmols(itype)*frac),1))`

and I found that `maxmove` was all 0, as it was only being parsed for the PDB file format.

## This PR:
- Sets the default value of `maxmove` to be the number of molecules of the type (as the default is according to the docs)
- Parses `maxmove` from the `structure` section of input regardless of file type.

## Testing
- Tested that this fixed the systems I failed to build, both using the default and explicitly defining maxmove in the input.
- Tests in `testing/` pass. 