### PR TITLE
Fix possible infinite loop guessing initial coordinates

### DIFF
--- a/src/initial.f90
+++ b/src/initial.f90
@@ -397,7 +397,7 @@ subroutine initial(n,x)
             fx = 1.d0
             ntry = 0
             overlap = .false.
-            do while(overlap .or. (fx > precision) .and. (ntry < max_guess_try))
+            do while((overlap .or. fx > precision) .and. (ntry < max_guess_try))
                overlap = .false.
                ntry = ntry + 1
                call random_number(xrnd)


### PR DESCRIPTION
With packmol > 21.0.0 I noticed hangs guessing the initial coordinates for some systems.
The maximum number of tries variable isn't being used due to a misplaced parentheses.

## Testing
- My system that hung infinitely now builds correctly.
- Tests in `testing/` pass.
- Used a git bisect to identify commit 589e4ca as the problem.