### PR TITLE
specify input and output files by command-line arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(packmol
        src/getinp.f90
        src/strlength.f90
        src/output.f90
+       src/cli_parser.f90
        src/checkpoint.f90
        src/writesuccess.f90
        src/fparc.f90

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ oall = cenmass.o \
        getinp.o \
        strlength.o \
        output.o \
+       cli_parser.o \
        checkpoint.o \
        writesuccess.o \
        fparc.o \
@@ -156,6 +157,8 @@ strlength.o : $(SRCDIR)/strlength.f90  $(modules)
 	@$(FORTRAN) $(FLAGS) -c $(SRCDIR)/strlength.f90
 output.o : $(SRCDIR)/output.f90  $(modules)
 	@$(FORTRAN) $(FLAGS) -c $(SRCDIR)/output.f90
+cli_parser.o : $(SRCDIR)/cli_parser.f90 $(modules)
+	@$(FORTRAN) $(FLAGS) -c $(SRCDIR)/cli_parser.f90
 checkpoint.o : $(SRCDIR)/checkpoint.f90  $(modules)
 	@$(FORTRAN) $(FLAGS) -c $(SRCDIR)/checkpoint.f90
 writesuccess.o : $(SRCDIR)/writesuccess.f90  $(modules)

--- a/app/packmol.f90
+++ b/app/packmol.f90
@@ -36,6 +36,7 @@ program packmol
   use exit_codes
   use sizes
   use compute_data
+  use cli_parser
   use input
   use usegencan
   use flashsort
@@ -80,6 +81,10 @@ program packmol
   ! Printing title
 
   call title()
+
+  ! Parse command-line arguments
+
+  call parse_command_line_args()
       
   ! Set dimensions of all arrays
 

--- a/src/cli_parser.f90
+++ b/src/cli_parser.f90
@@ -111,6 +111,32 @@ subroutine parse_command_line_args
             stop exit_code_command_line_error
         end if
 
+    else if (argc == 2) then ! user must specify the input file
+
+        cmdno = 1
+        call get_command_argument(cmdno, value=cmd, length=length, status=stat)
+        if (stat == -1) then
+            error stop "ERROR: truncation error"
+        else if (stat > 0) then
+            error stop "ERROR: command-line retrieval error"
+        end if
+
+        if (parse_command(cmd) == INPUT_FLAG) then
+            call get_filename(cmdno, input_file_name)
+            specified_input_file = .true.
+        else
+            error stop "ERROR: packmol show command-line usage"
+        end if
+
+        if (.not. specified_input_file) then
+            error stop "ERROR: packmol received invalid command-line arguments"
+        end if
+
+        if (len(trim(input_file_name)) == 0) then
+            write (*,*) "ERROR: invalid input filename"
+            stop exit_code_command_line_error
+        end if
+
     else if (argc == 4) then ! user has specified both the input and output files
 
         cmdno = 1

--- a/src/cli_parser.f90
+++ b/src/cli_parser.f90
@@ -1,0 +1,183 @@
+!
+!  Written by Misael Díaz-Maldonado, 2025.
+!  Copyright (c) 2009-2018, Leandro Martínez, Jose Mario Martinez,
+!  Ernesto G. Birgin.
+!
+
+module cli_parser
+
+    use sizes, only: strl
+    use exit_codes, only: exit_code_command_line_error
+    use input, only: output_file_name => xyzout
+    use input, only: input_file_name
+
+    implicit none
+
+    integer, parameter :: INPUT_FLAG = 0
+    integer, parameter :: OUTPUT_FLAG = 1
+
+    private
+    public :: parse_command_line_args
+
+contains
+
+function parse_command(cmd) result(res)
+    integer :: res
+    integer :: idx
+    character(*), intent(in) :: cmd
+    character(*), parameter :: cmdin = "-in"
+    character(*), parameter :: cmdout = "-out"
+    character(*), parameter :: errmsg = "ERROR: unrecognized command-line argument: "
+
+    idx = index(cmd, "-in")
+    if (idx /= 0) then
+
+        if (len(trim(cmd)) /= len(cmdin)) then
+                write(*,*) errmsg // trim(cmd)
+                stop exit_code_command_line_error
+        end if
+        res = INPUT_FLAG
+
+    else
+
+        idx = index(cmd, "-out")
+        if (idx == 0) then
+                write(*,*) errmsg // trim(cmd)
+                stop exit_code_command_line_error
+        end if
+        if (len(trim(cmd)) /= len(cmdout)) then
+                write(*,*) errmsg // trim(cmd)
+                stop exit_code_command_line_error
+        end if
+        res = OUTPUT_FLAG
+
+    end if
+
+    return
+end function parse_command
+
+subroutine get_filename(cmdno, filename)
+    integer, intent(in) :: cmdno
+    character(*), intent(out) :: filename
+
+    call get_command_argument(cmdno + 1, filename)
+
+    return
+end subroutine get_filename
+
+subroutine parse_command_line_args
+    integer :: idx
+    integer :: stat
+    integer :: argc
+    integer :: cmdno
+    integer :: length
+    logical :: specified_input_file
+    logical :: specified_output_file
+    character(len=strl) :: cmd
+    character(len=*), parameter :: errmsg = "ERROR: packmol command-line error show help"
+    character(len=*), parameter :: errcmp = "ERROR: packmol expects different " // &
+        "for the input and output files"
+
+    ! NOTE: Packmol will check the length of these strings later so don't remove this
+    input_file_name = ""
+    output_file_name = ""
+    specified_input_file = .false.
+    specified_output_file = .false.
+
+    argc = command_argument_count()
+    if (argc == 0) then ! packmol default mode with input redirection
+
+        cmdno = 0
+        call get_command_argument(cmdno, value=cmd, length=length, status=stat)
+        if (stat == -1) then
+            error stop "ERROR: truncation error"
+        else if (stat > 0) then
+            error stop "ERROR: command-line retrieval error"
+        end if
+
+        idx = index(cmd, "packmol")
+        if (idx == 0) then
+            write (*, *) "WARN: packmol detected non-standard command-line handling"
+        end if
+
+        ! NOTE: Packmol expects these to be initialized to empty strings
+        if (len(trim(input_file_name)) /= 0) then
+            write (*,*) "ERROR: packmol internal error"
+            stop exit_code_command_line_error
+        end if
+
+        if (len(trim(output_file_name)) /= 0) then
+            write (*,*) "ERROR: packmol internal error"
+            stop exit_code_command_line_error
+        end if
+
+    else if (argc == 4) then ! user has specified both the input and output files
+
+        cmdno = 1
+        call get_command_argument(cmdno, value=cmd, length=length, status=stat)
+        if (stat == -1) then
+            error stop "ERROR: truncation error"
+        else if (stat > 0) then
+            error stop "ERROR: command-line retrieval error"
+        end if
+
+        if (parse_command(cmd) == INPUT_FLAG) then
+            call get_filename(cmdno, input_file_name)
+            specified_input_file = .true.
+        else if (parse_command(cmd) == OUTPUT_FLAG) then
+            call get_filename(cmdno, output_file_name)
+            specified_output_file = .true.
+        else
+            error stop "ERROR: packmol received invalid command-line arguments"
+        end if
+
+        cmdno = 3
+        call get_command_argument(cmdno, value=cmd, length=length, status=stat)
+        if (specified_input_file) then
+            if (parse_command(cmd) == OUTPUT_FLAG) then
+                call get_filename(cmdno, output_file_name)
+                specified_output_file = .true.
+            end if
+        else
+            if (parse_command(cmd) == INPUT_FLAG) then
+                call get_filename(cmdno, input_file_name)
+                specified_input_file = .true.
+            else
+                error stop "ERROR: packmol received invalid command-line arguments"
+            end if
+        end if
+
+        ! assertion: both must be true if not we have a logic error in the code
+        if (.not. specified_input_file .or. .not. specified_output_file) then
+            error stop "ERROR: packmol received invalid command-line arguments"
+        end if
+
+        ! NOTE: we want to catch implementation errors in development
+        if (len(trim(input_file_name)) == 0) then
+            write (*,*) "ERROR: invalid input filename"
+            stop exit_code_command_line_error
+        end if
+
+        if (len(trim(output_file_name)) == 0) then
+            write (*,*) "ERROR: invalid output filename"
+            stop exit_code_command_line_error
+        end if
+
+        if (trim(input_file_name) == trim(output_file_name)) then
+            error stop errcmp
+        end if
+
+        write (*, *) "input: ", trim(input_file_name)
+        write (*, *) "output: ", trim(output_file_name)
+
+    else ! user provided invalid command-line arguments
+        error stop errmsg
+    end if
+
+    ! NOTE: for now we stop here until we update the rest of the source files
+    STOP
+
+    return
+end subroutine parse_command_line_args
+
+end module cli_parser

--- a/src/cli_parser.f90
+++ b/src/cli_parser.f90
@@ -25,11 +25,11 @@ function parse_command(cmd) result(res)
     integer :: res
     integer :: idx
     character(*), intent(in) :: cmd
-    character(*), parameter :: cmdin = "-in"
-    character(*), parameter :: cmdout = "-out"
+    character(*), parameter :: cmdin = "-i"
+    character(*), parameter :: cmdout = "-o"
     character(*), parameter :: errmsg = "ERROR: unrecognized command-line argument: "
 
-    idx = index(cmd, "-in")
+    idx = index(cmd, "-i")
     if (idx /= 0) then
 
         if (len(trim(cmd)) /= len(cmdin)) then
@@ -40,7 +40,7 @@ function parse_command(cmd) result(res)
 
     else
 
-        idx = index(cmd, "-out")
+        idx = index(cmd, "-o")
         if (idx == 0) then
                 write(*,*) errmsg // trim(cmd)
                 stop exit_code_command_line_error

--- a/src/cli_parser.f90
+++ b/src/cli_parser.f90
@@ -99,7 +99,7 @@ subroutine parse_command_line_args
 
         idx = index(cmd, "packmol")
         if (idx == 0) then
-            write (*, *) "WARN: packmol detected non-standard command-line handling"
+            write(*, *) "WARN: packmol detected non-standard command-line handling"
         end if
 
         ! NOTE: Packmol expects these to be initialized to empty strings

--- a/src/cli_parser.f90
+++ b/src/cli_parser.f90
@@ -90,9 +90,11 @@ subroutine parse_command_line_args
         cmdno = 0
         call get_command_argument(cmdno, value=cmd, length=length, status=stat)
         if (stat == -1) then
-            error stop "ERROR: truncation error"
+            write(*,*) "ERROR: truncation error"
+            stop exit_code_command_line_error
         else if (stat > 0) then
-            error stop "ERROR: command-line retrieval error"
+            write(*,*) "ERROR: command-line retrieval error"
+            stop exit_code_command_line_error
         end if
 
         idx = index(cmd, "packmol")
@@ -102,12 +104,12 @@ subroutine parse_command_line_args
 
         ! NOTE: Packmol expects these to be initialized to empty strings
         if (len(trim(input_file_name)) /= 0) then
-            write (*,*) "ERROR: packmol internal error"
+            write(*,*) "ERROR: packmol internal error"
             stop exit_code_command_line_error
         end if
 
         if (len(trim(output_file_name)) /= 0) then
-            write (*,*) "ERROR: packmol internal error"
+            write(*,*) "ERROR: packmol internal error"
             stop exit_code_command_line_error
         end if
 
@@ -116,24 +118,28 @@ subroutine parse_command_line_args
         cmdno = 1
         call get_command_argument(cmdno, value=cmd, length=length, status=stat)
         if (stat == -1) then
-            error stop "ERROR: truncation error"
+            write(*,*) "ERROR: truncation error"
+            stop exit_code_command_line_error
         else if (stat > 0) then
-            error stop "ERROR: command-line retrieval error"
+            write(*,*) "ERROR: command-line retrieval error"
+            stop exit_code_command_line_error
         end if
 
         if (parse_command(cmd) == INPUT_FLAG) then
             call get_filename(cmdno, input_file_name)
             specified_input_file = .true.
         else
-            error stop "ERROR: packmol show command-line usage"
+            write(*,*) "ERROR: packmol show command-line usage"
+            stop exit_code_command_line_error
         end if
 
         if (.not. specified_input_file) then
-            error stop "ERROR: packmol received invalid command-line arguments"
+            write(*,*) "ERROR: packmol received invalid command-line arguments"
+            stop exit_code_command_line_error
         end if
 
         if (len(trim(input_file_name)) == 0) then
-            write (*,*) "ERROR: invalid input filename"
+            write(*,*) "ERROR: invalid input filename"
             stop exit_code_command_line_error
         end if
 
@@ -142,9 +148,11 @@ subroutine parse_command_line_args
         cmdno = 1
         call get_command_argument(cmdno, value=cmd, length=length, status=stat)
         if (stat == -1) then
-            error stop "ERROR: truncation error"
+            write(*,*) "ERROR: truncation error"
+            stop exit_code_command_line_error
         else if (stat > 0) then
-            error stop "ERROR: command-line retrieval error"
+            write(*,*) "ERROR: command-line retrieval error"
+            stop exit_code_command_line_error
         end if
 
         if (parse_command(cmd) == INPUT_FLAG) then
@@ -154,7 +162,8 @@ subroutine parse_command_line_args
             call get_filename(cmdno, output_file_name)
             specified_output_file = .true.
         else
-            error stop "ERROR: packmol received invalid command-line arguments"
+            write(*,*) "ERROR: packmol received invalid command-line arguments"
+            stop exit_code_command_line_error
         end if
 
         cmdno = 3
@@ -169,32 +178,36 @@ subroutine parse_command_line_args
                 call get_filename(cmdno, input_file_name)
                 specified_input_file = .true.
             else
-                error stop "ERROR: packmol received invalid command-line arguments"
+                write(*,*) "ERROR: packmol received invalid command-line arguments"
+                stop exit_code_command_line_error
             end if
         end if
 
         ! assertion: both must be true if not we have a logic error in the code
         if (.not. specified_input_file .or. .not. specified_output_file) then
-            error stop "ERROR: packmol received invalid command-line arguments"
+            write(*,*) "ERROR: packmol received invalid command-line arguments"
+            stop exit_code_command_line_error
         end if
 
         ! NOTE: we want to catch implementation errors in development
         if (len(trim(input_file_name)) == 0) then
-            write (*,*) "ERROR: invalid input filename"
+            write(*,*) "ERROR: invalid input filename"
             stop exit_code_command_line_error
         end if
 
         if (len(trim(output_file_name)) == 0) then
-            write (*,*) "ERROR: invalid output filename"
+            write(*,*) "ERROR: invalid output filename"
             stop exit_code_command_line_error
         end if
 
         if (trim(input_file_name) == trim(output_file_name)) then
-            error stop errcmp
+            write(*,*) errcmp
+            stop exit_code_command_line_error
         end if
 
     else ! user provided invalid command-line arguments
-        error stop errmsg
+        write(*,*) errmsg
+        stop exit_code_command_line_error
     end if
 
     return

--- a/src/cli_parser.f90
+++ b/src/cli_parser.f90
@@ -174,9 +174,6 @@ subroutine parse_command_line_args
         error stop errmsg
     end if
 
-    ! NOTE: for now we stop here until we update the rest of the source files
-    STOP
-
     return
 end subroutine parse_command_line_args
 

--- a/src/cli_parser.f90
+++ b/src/cli_parser.f90
@@ -167,9 +167,6 @@ subroutine parse_command_line_args
             error stop errcmp
         end if
 
-        write (*, *) "input: ", trim(input_file_name)
-        write (*, *) "output: ", trim(output_file_name)
-
     else ! user provided invalid command-line arguments
         error stop errmsg
     end if

--- a/src/cli_parser.f90
+++ b/src/cli_parser.f90
@@ -15,6 +15,15 @@ module cli_parser
 
     integer, parameter :: INPUT_FLAG = 0
     integer, parameter :: OUTPUT_FLAG = 1
+    character(len=*), parameter :: errmsg = &
+        "ERROR: packmol command-line error" // new_line('a') // &
+        "Command-line execution examples (you may use any): " // new_line('a') // &
+        "" // new_line('a') // &
+        "packmol < input.inp" // new_line('a') // &
+        "" // new_line('a') // &
+        "packmol -i input.inp" // new_line('a') // &
+        "" // new_line('a') // &
+        "packmol -i input.inp -o output.pdb" // new_line('a')
 
     private
     public :: parse_command_line_args
@@ -27,13 +36,14 @@ function parse_command(cmd) result(res)
     character(*), intent(in) :: cmd
     character(*), parameter :: cmdin = "-i"
     character(*), parameter :: cmdout = "-o"
-    character(*), parameter :: errmsg = "ERROR: unrecognized command-line argument: "
+    character(*), parameter :: err = "ERROR: unrecognized command-line argument: "
 
     idx = index(cmd, "-i")
     if (idx /= 0) then
 
         if (len(trim(cmd)) /= len(cmdin)) then
-                write(*,*) errmsg // trim(cmd)
+                write(*,*) err // trim(cmd)
+                write(*,*) errmsg
                 stop exit_code_command_line_error
         end if
         res = INPUT_FLAG
@@ -42,11 +52,13 @@ function parse_command(cmd) result(res)
 
         idx = index(cmd, "-o")
         if (idx == 0) then
-                write(*,*) errmsg // trim(cmd)
+                write(*,*) err // trim(cmd)
+                write(*,*) errmsg
                 stop exit_code_command_line_error
         end if
         if (len(trim(cmd)) /= len(cmdout)) then
-                write(*,*) errmsg // trim(cmd)
+                write(*,*) err // trim(cmd)
+                write(*,*) errmsg
                 stop exit_code_command_line_error
         end if
         res = OUTPUT_FLAG
@@ -74,7 +86,6 @@ subroutine parse_command_line_args
     logical :: specified_input_file
     logical :: specified_output_file
     character(len=strl) :: cmd
-    character(len=*), parameter :: errmsg = "ERROR: packmol command-line error show help"
     character(len=*), parameter :: errcmp = "ERROR: packmol expects different " // &
         "for the input and output files"
 
@@ -91,9 +102,11 @@ subroutine parse_command_line_args
         call get_command_argument(cmdno, value=cmd, length=length, status=stat)
         if (stat == -1) then
             write(*,*) "ERROR: truncation error"
+            write(*,*) errmsg
             stop exit_code_command_line_error
         else if (stat > 0) then
             write(*,*) "ERROR: command-line retrieval error"
+            write(*,*) errmsg
             stop exit_code_command_line_error
         end if
 
@@ -104,12 +117,12 @@ subroutine parse_command_line_args
 
         ! NOTE: Packmol expects these to be initialized to empty strings
         if (len(trim(input_file_name)) /= 0) then
-            write(*,*) "ERROR: packmol internal error"
+            write(*,*) "ERROR: packmol command-line implementation error"
             stop exit_code_command_line_error
         end if
 
         if (len(trim(output_file_name)) /= 0) then
-            write(*,*) "ERROR: packmol internal error"
+            write(*,*) "ERROR: packmol command-line implementation error"
             stop exit_code_command_line_error
         end if
 
@@ -119,9 +132,11 @@ subroutine parse_command_line_args
         call get_command_argument(cmdno, value=cmd, length=length, status=stat)
         if (stat == -1) then
             write(*,*) "ERROR: truncation error"
+            write(*,*) errmsg
             stop exit_code_command_line_error
         else if (stat > 0) then
             write(*,*) "ERROR: command-line retrieval error"
+            write(*,*) errmsg
             stop exit_code_command_line_error
         end if
 
@@ -129,17 +144,19 @@ subroutine parse_command_line_args
             call get_filename(cmdno, input_file_name)
             specified_input_file = .true.
         else
-            write(*,*) "ERROR: packmol show command-line usage"
+            write(*,*) errmsg
             stop exit_code_command_line_error
         end if
 
         if (.not. specified_input_file) then
             write(*,*) "ERROR: packmol received invalid command-line arguments"
+            write(*,*) errmsg
             stop exit_code_command_line_error
         end if
 
         if (len(trim(input_file_name)) == 0) then
             write(*,*) "ERROR: invalid input filename"
+            write(*,*) errmsg
             stop exit_code_command_line_error
         end if
 
@@ -149,9 +166,11 @@ subroutine parse_command_line_args
         call get_command_argument(cmdno, value=cmd, length=length, status=stat)
         if (stat == -1) then
             write(*,*) "ERROR: truncation error"
+            write(*,*) errmsg
             stop exit_code_command_line_error
         else if (stat > 0) then
             write(*,*) "ERROR: command-line retrieval error"
+            write(*,*) errmsg
             stop exit_code_command_line_error
         end if
 
@@ -163,6 +182,7 @@ subroutine parse_command_line_args
             specified_output_file = .true.
         else
             write(*,*) "ERROR: packmol received invalid command-line arguments"
+            write(*,*) errmsg
             stop exit_code_command_line_error
         end if
 
@@ -179,6 +199,7 @@ subroutine parse_command_line_args
                 specified_input_file = .true.
             else
                 write(*,*) "ERROR: packmol received invalid command-line arguments"
+                write(*,*) errmsg
                 stop exit_code_command_line_error
             end if
         end if
@@ -186,22 +207,26 @@ subroutine parse_command_line_args
         ! assertion: both must be true if not we have a logic error in the code
         if (.not. specified_input_file .or. .not. specified_output_file) then
             write(*,*) "ERROR: packmol received invalid command-line arguments"
+            write(*,*) errmsg
             stop exit_code_command_line_error
         end if
 
         ! NOTE: we want to catch implementation errors in development
         if (len(trim(input_file_name)) == 0) then
             write(*,*) "ERROR: invalid input filename"
+            write(*,*) errmsg
             stop exit_code_command_line_error
         end if
 
         if (len(trim(output_file_name)) == 0) then
             write(*,*) "ERROR: invalid output filename"
+            write(*,*) errmsg
             stop exit_code_command_line_error
         end if
 
         if (trim(input_file_name) == trim(output_file_name)) then
             write(*,*) errcmp
+            write(*,*) errmsg
             stop exit_code_command_line_error
         end if
 

--- a/src/exit_codes.f90
+++ b/src/exit_codes.f90
@@ -14,5 +14,6 @@ module exit_codes
    integer, parameter :: exit_code_input_error = 171
    integer, parameter :: exit_code_open_file = 172
    integer, parameter :: exit_code_failed_to_converge = 173
+   integer, parameter :: exit_code_command_line_error = 174
 
 end module exit_codes

--- a/src/getinp.f90
+++ b/src/getinp.f90
@@ -256,6 +256,7 @@ subroutine getinp()
 
    ! Checking for the name of the output file to be created
 
+   if (len(trim(xyzout)) == 0) then
    xyzout = '####'
    do iline = 1, nlines
       if(keyword(iline,1).eq.'output') then
@@ -267,7 +268,10 @@ subroutine getinp()
       write(*,*)' ERROR: Output file not (correctly?) specified. '
       stop exit_code_input_error
    end if
+   end if
    write(*,*)' Output file: ', trim(adjustl(xyzout))
+   ! for now we stop here
+   STOP
 
    ! Reading structure files
 

--- a/src/getinp.f90
+++ b/src/getinp.f90
@@ -270,8 +270,6 @@ subroutine getinp()
       end if
    end if
    write(*,*)' Output file: ', trim(adjustl(xyzout))
-   ! for now we stop here
-   STOP
 
    ! Reading structure files
 

--- a/src/getinp.f90
+++ b/src/getinp.f90
@@ -257,17 +257,17 @@ subroutine getinp()
    ! Checking for the name of the output file to be created
 
    if (len(trim(xyzout)) == 0) then
-   xyzout = '####'
-   do iline = 1, nlines
-      if(keyword(iline,1).eq.'output') then
-         xyzout = keyword(iline,2)
-         xyzout = trim(adjustl(xyzout))
+      xyzout = '####'
+      do iline = 1, nlines
+         if(keyword(iline,1).eq.'output') then
+            xyzout = keyword(iline,2)
+            xyzout = trim(adjustl(xyzout))
+         end if
+      end do
+      if(xyzout(1:4) == '####') then
+         write(*,*)' ERROR: Output file not (correctly?) specified. '
+         stop exit_code_input_error
       end if
-   end do
-   if(xyzout(1:4) == '####') then
-      write(*,*)' ERROR: Output file not (correctly?) specified. '
-      stop exit_code_input_error
-   end if
    end if
    write(*,*)' Output file: ', trim(adjustl(xyzout))
    ! for now we stop here

--- a/src/input.f90
+++ b/src/input.f90
@@ -66,6 +66,7 @@ module input
    logical, allocatable :: connect(:) ! (ntype)
 
    character(len=1), parameter :: forbidden_char = '~'
+   character(len=strl) :: input_file_name
    character(len=strl) :: xyzout
    character(len=strl) :: crdfile
 

--- a/src/setsizes.f90
+++ b/src/setsizes.f90
@@ -358,7 +358,5 @@ subroutine setsizes()
       close(un)
    end if
 
-   ! for now we stop here until we update other source files accordingly
-   STOP
 end subroutine setsizes
 

--- a/src/setsizes.f90
+++ b/src/setsizes.f90
@@ -40,7 +40,7 @@ subroutine setsizes()
       un = 100
       open(unit=un, file=trim(input_file_name), status="unknown", iostat=ioerr)
       if (ioerr /= 0) then
-         write (*, *) "ERROR: file-open error with file: " // trim(input_file_name)
+         write(*, *) "ERROR: file-open error with file: " // trim(input_file_name)
          stop exit_code_open_file
       end if
    end if

--- a/src/setsizes.f90
+++ b/src/setsizes.f90
@@ -18,6 +18,7 @@ subroutine setsizes()
    implicit none
    integer :: i, ival, ilast, iline, itype
    integer :: ioerr
+   integer :: un
    integer :: strlength
    character(len=strl) :: record, blank, alltospace
    logical :: inside_structure
@@ -33,6 +34,17 @@ subroutine setsizes()
 
    write(*,*) ' Reading input file... (Control-C aborts)'
 
+   if (len(trim(input_file_name)) == 0) then
+      un = 5
+   else
+      un = 100
+      open(unit=un, file=trim(input_file_name), status="unknown", iostat=ioerr)
+      if (ioerr /= 0) then
+         write (*, *) "ERROR: file-open error with file: " // trim(input_file_name)
+         stop exit_code_open_file
+      end if
+   end if
+
    do i = 1, strl
       blank(i:i) = ' '
    end do
@@ -40,7 +52,7 @@ subroutine setsizes()
    maxkeywords = 0
    ntype = 0
    do
-      read(5,str_format,iostat=ioerr) record
+      read(un,str_format,iostat=ioerr) record
 
       ! Replace any strange blank character by spaces
       record = alltospace(record)
@@ -88,7 +100,7 @@ subroutine setsizes()
          end if
       end do
    end do
-   rewind(5)
+   rewind(un)
 
    allocate(inputfile(nlines),keyword(nlines,maxkeywords))
 
@@ -96,7 +108,7 @@ subroutine setsizes()
 
    iline = 0
    do
-      read(5,str_format,iostat=ioerr) record
+      read(un,str_format,iostat=ioerr) record
       if ( ioerr /= 0 ) exit
 
       ! Convert all strange blank characters to spaces
@@ -342,5 +354,11 @@ subroutine setsizes()
 
    allocate(l(nn),u(nn),wd(8*nn),wi(nn),g(nn))
 
+   if (un /= 5) then
+      close(un)
+   end if
+
+   ! for now we stop here until we update other source files accordingly
+   STOP
 end subroutine setsizes
 

--- a/testing/test.sh
+++ b/testing/test.sh
@@ -30,3 +30,5 @@ $julia_exe runtests.jl ./input_files/water_box.inp \
 # Test connectivity
 ./test_connectivity.sh 
 
+# Test command-line interface
+./test_cli.sh ../packmol

--- a/testing/test_cli.sh
+++ b/testing/test_cli.sh
@@ -111,7 +111,7 @@ fi
 pass=0
 "$ls" input_files/*.inp | while read input_file
 do
-	sw=$(echo "$input_file" | "$grep" -v "error" | "$grep" -v "fail" | "$wc" --chars)
+	sw=$(echo "$input_file" | "$grep" -v "error" | "$grep" -v "fail" | "$wc" -c)
 	if [ "$sw" -eq 0 ] ; then
 		if [ "$verbose" -eq 1 ] ; then
 			echo "Skipping test $input_file because it is designed to fail"
@@ -182,8 +182,8 @@ do
 		continue
 	fi
 
-	res1=$("$diff" --normal "$output_pdb" "$output_txt" | "$wc" --chars)
-	res2=$("$diff" --normal "$output_pdb" "$output_tmp" | "$wc" --chars)
+	res1=$("$diff" --normal "$output_pdb" "$output_txt" | "$wc" -c)
+	res2=$("$diff" --normal "$output_pdb" "$output_tmp" | "$wc" -c)
 	if [ "$res1" -eq 0 ] && [ "$res2" -eq 0 ] ; then
 		echo "OK"
 	else

--- a/testing/test_cli.sh
+++ b/testing/test_cli.sh
@@ -20,6 +20,7 @@
 
 verbose=0
 
+# checks number of command-line arguments given
 if [ "$#" -ne 1 ] ; then
 	echo "Error: expects the path to packmol as the first command-line argument"
 	echo "Example: ./test_cli.sh /usr/bin/packmol"
@@ -27,6 +28,7 @@ if [ "$#" -ne 1 ] ; then
 fi
 
 packmol="$1"
+# checks that we can execute packmol
 if ! [ -f "$packmol" ] ; then
 	echo "Error: packmol does not exist"
 	exit 1
@@ -37,11 +39,13 @@ if ! [ -x "$packmol" ] ; then
 	exit 1
 fi
 
+# checks that the input_files directo exists
 if ! [ -d input_files ] ; then
 	echo "Error: the 'input_files' directory does not exist"
 	exit 1
 fi
 
+# checks that all the commands this script depends exists for the sake of completeness
 ls=$(which ls)
 if ! [ -x "$ls" ] ; then
 	echo "Error: ls command not found"
@@ -97,6 +101,7 @@ if ! [ -x "$uname" ] ; then
 fi
 
 os=$("$uname")
+# OSX does not ship with GNU gawk by default so we need to use what they provide
 if [ "Darwin" == "$os" ] ; then
 	gawk=$(which awk)
 else
@@ -108,8 +113,14 @@ if ! [ -x "$gawk" ] ; then
 	exit 1
 fi
 
+# for each input file in the input_files directory run packmol and check that we get the
+# same results (same contents in the output file) regardless of the invokation method
+# used to execute packmol
 "$ls" input_files/*.inp | while read input_file
 do
+	# here we use pattern matching to exclude input_files that we know would fail
+	# because they are meant to fail; since that would mess our test we filter
+	# those out with grep
 	sw=$(echo "$input_file" | "$grep" -v "error" | "$grep" -v "fail" | "$wc" -c)
 	if [ "$sw" -eq 0 ] ; then
 		if [ "$verbose" -eq 1 ] ; then
@@ -118,6 +129,9 @@ do
 		continue
 	fi
 
+	# we need to patch some of the data in the original input files this is why we
+	# create .txt and .tmp versions; we use regex to replace the .inp with either
+	# .txt or .tmp extensions
 	input_txt=$(\
 		echo "$input_file" |\
 		"$sed" 's/\.inp/.txt/g'
@@ -128,6 +142,10 @@ do
 		"$sed" 's/\.inp/.tmp/g'
 	)
 
+	# We fix the `seed` value on those input_files that set it to -1; otherwise
+	# packmol could yield different results and we don't want that of course, we
+	# want reproducible results for the same input. That is why we provide a fix
+	# value for the seed.
 	"$cp" "$input_file" "$input_txt"
 	"$sed" -e 's/seed -1/seed 1024/g' -i'.tmp' "$input_txt"
 	"$cp" "$input_txt" "$input_tmp"
@@ -135,17 +153,20 @@ do
 	"$rm" "$input_txt.tmp"
 	"$rm" "$input_tmp.tmp"
 
+	# here we extract the name of the output file from the input-file
 	output_pdb=$(\
 		"$cat" "$input_txt" | \
 		"$grep" "output" | \
 		"$gawk" '{print $2}'
 	)
 
+	# uses substitution to produce an output file with a .txt file extension
 	output_txt=$(\
 		echo "$output_pdb" | \
 		"$sed" 's/\.pdb/.txt/g'
 	)
 
+	# uses substitution to produce an output file with a .tmp file extension
 	output_tmp=$(\
 		echo "$output_pdb" | \
 		"$sed" 's/\.pdb/.tmp/g'
@@ -153,6 +174,7 @@ do
 
 	echo -n "Running test $input_txt ... "
 
+	# runs packmol in the usual way with input redirection
 	if ! "$packmol" < "$input_txt" 1>/dev/null 2>/dev/null ; then
 		echo "FAIL"
 		"$rm" -f "$input_tmp"
@@ -163,6 +185,11 @@ do
 		exit 1
 	fi
 
+	# Provides the input file via command-line to packmol and executes it;
+	# we redirect the standard output and error to the null-device to keep
+	# our test output clean. In this case the output file is determined from
+	# the input-file `input_tmp`; note that the output file will have a .tmp
+	# file extension because of the preprocessing that we have done.
 	if ! "$packmol" -i "$input_tmp" 1>/dev/null 2>/dev/null ; then
 		echo "FAIL"
 		"$rm" -f "$input_tmp"
@@ -173,6 +200,7 @@ do
 		exit 1
 	fi
 
+	# provides both the input and output files to packmol and executes it
 	if ! "$packmol" -i "$input_txt" -o "$output_txt" 1>/dev/null 2>/dev/null ; then
 		echo "FAIL"
 		"$rm" -f "$input_tmp"
@@ -183,6 +211,9 @@ do
 		exit 1
 	fi
 
+	# here we check that the output files are identical via GNU diffutil;
+	# to do that we concatenate the diff contents and determine the number of
+	# bytes (we should get zero bytes when they are the same)
 	res1=$("$diff" --normal "$output_pdb" "$output_txt" | "$wc" -c)
 	res2=$("$diff" --normal "$output_pdb" "$output_tmp" | "$wc" -c)
 	if [ "$res1" -eq 0 ] && [ "$res2" -eq 0 ] ; then
@@ -197,6 +228,7 @@ do
 		exit 1
 	fi
 
+	# we clean up the testing directory from our temporary files
 	"$rm" -f "$input_tmp"
 	"$rm" -f "$input_txt"
 	"$rm" -f "$output_txt"
@@ -204,4 +236,5 @@ do
 	"$rm" -f "$output_tmp"
 done
 
+# if we get here packmol passed all the tests successfully
 exit 0

--- a/testing/test_cli.sh
+++ b/testing/test_cli.sh
@@ -130,9 +130,9 @@ do
 	)
 
 	"$cp" "$input_file" "$input_txt"
-	"$sed" -i 's/seed\s\+-1/seed 1024/g' "$input_txt"
+	"$sed" -i'' 's/seed\s\+-1/seed 1024/g' "$input_txt"
 	"$cp" "$input_txt" "$input_tmp"
-	"$sed" -i 's/output\s\+\(\w\+\)\.pdb/output \1.tmp/g' "$input_tmp"
+	"$sed" -i'' 's/output\s\+\(\w\+\)\.pdb/output \1.tmp/g' "$input_tmp"
 
 	output_pdb=$(\
 		"$cat" "$input_txt" | \

--- a/testing/test_cli.sh
+++ b/testing/test_cli.sh
@@ -48,6 +48,12 @@ if ! [ -x "$ls" ] ; then
 	exit 1
 fi
 
+mv=$(which mv)
+if ! [ -x "$mv" ] ; then
+	echo "Error: mv command not found"
+	exit 1
+fi
+
 cp=$(which cp)
 if ! [ -x "$cp" ] ; then
 	echo "Error: cp command not found"
@@ -132,7 +138,7 @@ do
 	"$cp" "$input_file" "$input_txt"
 	"$sed" -e 's/seed\s\+-1/seed 1024/g' -i'.tmp' "$input_txt"
 	"$cp" "$input_txt" "$input_tmp"
-	"$sed" -e 's/\.pdb/.tmp/g' -i'.tmp' "$input_tmp"
+	"$sed" -e 's/output\.pdb/output.tmp/g' -i'.tmp' "$input_tmp"
 
 	output_pdb=$(\
 		"$cat" "$input_txt" | \

--- a/testing/test_cli.sh
+++ b/testing/test_cli.sh
@@ -48,12 +48,6 @@ if ! [ -x "$ls" ] ; then
 	exit 1
 fi
 
-mv=$(which mv)
-if ! [ -x "$mv" ] ; then
-	echo "Error: mv command not found"
-	exit 1
-fi
-
 cp=$(which cp)
 if ! [ -x "$cp" ] ; then
 	echo "Error: cp command not found"

--- a/testing/test_cli.sh
+++ b/testing/test_cli.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+#
+# Synopsis:
+# Test the command-line interface by checking if executing packmol with command-line
+# arguments changes results. The script checks for differences in the output files with
+# the GNU diffutil. All the supported ways to invoke packmol are considered.
+#
+# Written by Misael Díaz-Maldonado, 2025
+#
+# Copyright (c) 2009-2018, Leandro Martínez, Jose Mario Martinez,
+# Ernesto G. Birgin.
+#
+# Example invokation of this shell script: ./test_cli.sh /usr/bin/packmol
+#
+# NOTES:
+# We skip tests designed to fail and we patch input files with a seed equal to -1 because
+# that will also fail our test because that signals packmol to generate a seed based on
+# the current time and so results are expected to be different.
+#
+
+verbose=0
+
+if [ "$#" -ne 1 ] ; then
+	echo "Error: expects the path to packmol as the first command-line argument"
+	echo "Example: ./test_cli.sh /usr/bin/packmol"
+	exit 1
+fi
+
+packmol="$1"
+if ! [ -f "$packmol" ] ; then
+	echo "Error: packmol does not exist"
+	exit 1
+fi
+
+if ! [ -x "$packmol" ] ; then
+	echo "Error: cannot execute packmol"
+	exit 1
+fi
+
+if ! [ -d input_files ] ; then
+	echo "Error: the 'input_files' directory does not exist"
+	exit 1
+fi
+
+ls=$(which ls)
+if ! [ -x "$ls" ] ; then
+	echo "Error: ls command not found"
+	exit 1
+fi
+
+cp=$(which cp)
+if ! [ -x "$cp" ] ; then
+	echo "Error: cp command not found"
+	exit 1
+fi
+
+rm=$(which rm)
+if ! [ -x "$rm" ] ; then
+	echo "Error: rm command not found"
+	exit 1
+fi
+
+wc=$(which wc)
+if ! [ -x "$wc" ] ; then
+	echo "Error: wc command not found"
+	exit 1
+fi
+
+cat=$(which cat)
+if ! [ -x "$cat" ] ; then
+	echo "Error: cat command not found"
+	exit 1
+fi
+
+sed=$(which sed)
+if ! [ -x "$sed" ] ; then
+	echo "Error: sed command not found"
+	exit 1
+fi
+
+diff=$(which diff)
+if ! [ -x "$diff" ] ; then
+	echo "Error: diff command not found"
+	exit 1
+fi
+
+grep=$(which grep)
+if ! [ -x "$grep" ] ; then
+	echo "Error: grep command not found"
+	exit 1
+fi
+
+gawk=$(which gawk)
+if ! [ -x "$gawk" ] ; then
+	echo "Error: gawk command not found"
+	exit 1
+fi
+
+pass=0
+"$ls" input_files/*.inp | while read input_file
+do
+	sw=$(echo "$input_file" | "$grep" -v "error" | "$grep" -v "fail" | "$wc" --chars)
+	if [ "$sw" -eq 0 ] ; then
+		if [ "$verbose" -eq 1 ] ; then
+			echo "Skipping test $input_file because it is designed to fail"
+		fi
+		continue
+	fi
+
+	input_txt=$(\
+		echo "$input_file" |\
+		"$sed" 's/\.inp/.txt/g'
+	)
+
+	input_tmp=$(\
+		echo "$input_file" |\
+		"$sed" 's/\.inp/.tmp/g'
+	)
+
+	"$cp" "$input_file" "$input_txt"
+	"$sed" -i 's/seed\s\+-1/seed 1024/g' "$input_txt"
+	"$cp" "$input_txt" "$input_tmp"
+	"$sed" -i 's/output\s\+\(\w\+\)\.pdb/output \1.tmp/g' "$input_tmp"
+
+	output_pdb=$(\
+		"$cat" "$input_txt" | \
+		"$grep" "output" | \
+		"$gawk" '{print $2}'
+	)
+
+	output_txt=$(\
+		echo "$output_pdb" | \
+		"$sed" 's/\.pdb/.txt/g'
+	)
+
+	output_tmp=$(\
+		echo "$output_pdb" | \
+		"$sed" 's/\.pdb/.tmp/g'
+	)
+
+	echo -n "Running test $input_txt ... "
+
+	if ! "$packmol" < "$input_txt" 1>/dev/null 2>/dev/null ; then
+		echo "FAIL"
+		"$rm" -f "$input_tmp"
+		"$rm" -f "$input_txt"
+		"$rm" -f "$output_txt"
+		"$rm" -f "$output_pdb"
+		"$rm" -f "$output_tmp"
+		continue
+	fi
+
+	if ! "$packmol" -i "$input_tmp" 1>/dev/null 2>/dev/null ; then
+		echo "FAIL"
+		"$rm" -f "$input_tmp"
+		"$rm" -f "$input_txt"
+		"$rm" -f "$output_txt"
+		"$rm" -f "$output_pdb"
+		"$rm" -f "$output_tmp"
+		continue
+	fi
+
+	if ! "$packmol" -i "$input_txt" -o "$output_txt" 1>/dev/null 2>/dev/null ; then
+		echo "FAIL"
+		"$rm" -f "$input_tmp"
+		"$rm" -f "$input_txt"
+		"$rm" -f "$output_txt"
+		"$rm" -f "$output_pdb"
+		"$rm" -f "$output_tmp"
+		continue
+	fi
+
+	res1=$("$diff" --normal "$output_pdb" "$output_txt" | "$wc" --chars)
+	res2=$("$diff" --normal "$output_pdb" "$output_tmp" | "$wc" --chars)
+	if [ "$res1" -eq 0 ] && [ "$res2" -eq 0 ] ; then
+		echo "OK"
+	else
+		echo "FAIL"
+		pass=1
+	fi
+
+	"$rm" -f "$input_tmp"
+	"$rm" -f "$input_txt"
+	"$rm" -f "$output_txt"
+	"$rm" -f "$output_pdb"
+	"$rm" -f "$output_tmp"
+done
+
+if [ "$pass" -eq 0 ] ; then
+	exit 0
+else
+	exit 1
+fi

--- a/testing/test_cli.sh
+++ b/testing/test_cli.sh
@@ -130,9 +130,9 @@ do
 	)
 
 	"$cp" "$input_file" "$input_txt"
-	"$sed" -i'' 's/seed\s\+-1/seed 1024/g' "$input_txt"
+	"$sed" -i'.tmp' 's/seed\s\+-1/seed 1024/g' "$input_txt"
 	"$cp" "$input_txt" "$input_tmp"
-	"$sed" -i'' 's/output\s\+\(\w\+\)\.pdb/output \1.tmp/g' "$input_tmp"
+	"$sed" -i'.tmp' 's/output\s\+\(\w\+\)\.pdb/output \1.tmp/g' "$input_tmp"
 
 	output_pdb=$(\
 		"$cat" "$input_txt" | \

--- a/testing/test_cli.sh
+++ b/testing/test_cli.sh
@@ -90,7 +90,19 @@ if ! [ -x "$grep" ] ; then
 	exit 1
 fi
 
-gawk=$(which gawk)
+uname=$(which uname)
+if ! [ -x "$uname" ] ; then
+	echo "Error: uname command not found"
+	exit 1
+fi
+
+os="$uname"
+if [ "Darwin" == "$os" ] ; then
+	gawk=$(which awk)
+else
+	gawk=$(which gawk)
+fi
+
 if ! [ -x "$gawk" ] ; then
 	echo "Error: gawk command not found"
 	exit 1

--- a/testing/test_cli.sh
+++ b/testing/test_cli.sh
@@ -130,7 +130,7 @@ do
 	)
 
 	"$cp" "$input_file" "$input_txt"
-	"$sed" -e 's/seed\s\+-1/seed 1024/g' -i'.tmp' "$input_txt"
+	"$sed" -e 's/seed -1/seed 1024/g' -i'.tmp' "$input_txt"
 	"$cp" "$input_txt" "$input_tmp"
 	"$sed" -e 's/output\.pdb/output.tmp/g' -i'.tmp' "$input_tmp"
 

--- a/testing/test_cli.sh
+++ b/testing/test_cli.sh
@@ -132,7 +132,7 @@ do
 	"$cp" "$input_file" "$input_txt"
 	"$sed" -e 's/seed\s\+-1/seed 1024/g' -i'.tmp' "$input_txt"
 	"$cp" "$input_txt" "$input_tmp"
-	"$sed" -e 's/output\s\+\(\w\+\)\.pdb/output \1.tmp/g' -i'.tmp' "$input_tmp"
+	"$sed" -e 's/\.pdb/.tmp/g' -i'.tmp' "$input_tmp"
 
 	output_pdb=$(\
 		"$cat" "$input_txt" | \

--- a/testing/test_cli.sh
+++ b/testing/test_cli.sh
@@ -133,6 +133,8 @@ do
 	"$sed" -e 's/seed -1/seed 1024/g' -i'.tmp' "$input_txt"
 	"$cp" "$input_txt" "$input_tmp"
 	"$sed" -e 's/output\.pdb/output.tmp/g' -i'.tmp' "$input_tmp"
+	"$rm" "$input_txt.tmp"
+	"$rm" "$input_tmp.tmp"
 
 	output_pdb=$(\
 		"$cat" "$input_txt" | \

--- a/testing/test_cli.sh
+++ b/testing/test_cli.sh
@@ -108,7 +108,6 @@ if ! [ -x "$gawk" ] ; then
 	exit 1
 fi
 
-pass=0
 "$ls" input_files/*.inp | while read input_file
 do
 	sw=$(echo "$input_file" | "$grep" -v "error" | "$grep" -v "fail" | "$wc" -c)
@@ -161,7 +160,7 @@ do
 		"$rm" -f "$output_txt"
 		"$rm" -f "$output_pdb"
 		"$rm" -f "$output_tmp"
-		continue
+		exit 1
 	fi
 
 	if ! "$packmol" -i "$input_tmp" 1>/dev/null 2>/dev/null ; then
@@ -171,7 +170,7 @@ do
 		"$rm" -f "$output_txt"
 		"$rm" -f "$output_pdb"
 		"$rm" -f "$output_tmp"
-		continue
+		exit 1
 	fi
 
 	if ! "$packmol" -i "$input_txt" -o "$output_txt" 1>/dev/null 2>/dev/null ; then
@@ -181,7 +180,7 @@ do
 		"$rm" -f "$output_txt"
 		"$rm" -f "$output_pdb"
 		"$rm" -f "$output_tmp"
-		continue
+		exit 1
 	fi
 
 	res1=$("$diff" --normal "$output_pdb" "$output_txt" | "$wc" -c)
@@ -190,7 +189,12 @@ do
 		echo "OK"
 	else
 		echo "FAIL"
-		pass=1
+		"$rm" -f "$input_tmp"
+		"$rm" -f "$input_txt"
+		"$rm" -f "$output_txt"
+		"$rm" -f "$output_pdb"
+		"$rm" -f "$output_tmp"
+		exit 1
 	fi
 
 	"$rm" -f "$input_tmp"
@@ -200,8 +204,4 @@ do
 	"$rm" -f "$output_tmp"
 done
 
-if [ "$pass" -eq 0 ] ; then
-	exit 0
-else
-	exit 1
-fi
+exit 0

--- a/testing/test_cli.sh
+++ b/testing/test_cli.sh
@@ -130,9 +130,9 @@ do
 	)
 
 	"$cp" "$input_file" "$input_txt"
-	"$sed" -i'.tmp' 's/seed\s\+-1/seed 1024/g' "$input_txt"
+	"$sed" -e 's/seed\s\+-1/seed 1024/g' -i'.tmp' "$input_txt"
 	"$cp" "$input_txt" "$input_tmp"
-	"$sed" -i'.tmp' 's/output\s\+\(\w\+\)\.pdb/output \1.tmp/g' "$input_tmp"
+	"$sed" -e 's/output\s\+\(\w\+\)\.pdb/output \1.tmp/g' -i'.tmp' "$input_tmp"
 
 	output_pdb=$(\
 		"$cat" "$input_txt" | \

--- a/testing/test_cli.sh
+++ b/testing/test_cli.sh
@@ -96,7 +96,7 @@ if ! [ -x "$uname" ] ; then
 	exit 1
 fi
 
-os="$uname"
+os=$("$uname")
 if [ "Darwin" == "$os" ] ; then
 	gawk=$(which awk)
 else


### PR DESCRIPTION
I am submitting this PR so that you can see more clearly what changes I have made to packmol's source code in order to implement this feature.

The proposed feature allows users to specify the names of the input and output files via command-line arguments, while being backwards compatible.

It is proposed to execute packmol with command-line arguments is the following way:

```sh
packmol -in input.txt -out output.txt
```

Users may still use packmol with input redirection if they wish to do so:

```sh
packmol < input.txt
```

in that case the name of the output file must be present in `input.txt` by providing the respective `output` keyword and value pair.

I shall add the tests that you have requested to test the interface automatically via CI.

closes https://github.com/m3g/packmol/issues/100